### PR TITLE
Fix: Update pypa/gh-action-pypi-publish to supported version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary
- Updates the deprecated `pypa/gh-action-pypi-publish@master` to `pypa/gh-action-pypi-publish@release/v1`
- This fixes the CI/CD pipeline failures that occurred after merging Dependabot PRs

## Problem
The CI/CD workflow was failing with the error:
```
You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes.
```

This was causing all deployments to fail with a 403 Forbidden error when trying to publish to PyPI.

## Solution
Updated the action to use the stable `release/v1` branch as recommended in the error message.

## Test Plan
- [x] Created pull request with the fix
- [ ] CI/CD pipeline should pass on this PR
- [ ] Future merges to main should successfully deploy to PyPI

Fixes the deployment failures from PRs #2, #3, #4, #5, and #6.