### PR TITLE
fix: restore Tesla Owner API by pinning teslapy>=2.9.2 (TLS 1.3)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,3 +26,18 @@ jobs:
           pip install flake8
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  test:  # Run the test suite so regressions (e.g. the TLS 1.3 fix) fail CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Run tests
+        run: pytest -v

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: '3.13'  # match the test job and runtime image
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,10 @@ services:
     container_name: teslaontarget
     restart: unless-stopped
     user: teslauser
-    read_only: true
+    # NOTE: the entrypoint writes config.py and cache symlinks into /app, so the
+    # root filesystem must be writable. Hardened read-only mode (config -> tmpfs,
+    # teslapy cache_file -> /data) is tracked for the uv modernization PR.
+    read_only: false
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -59,7 +62,10 @@ services:
     stdin_open: true
     tty: true
     user: teslauser
-    read_only: true
+    # NOTE: the entrypoint writes config.py and cache symlinks into /app, so the
+    # root filesystem must be writable. Hardened read-only mode (config -> tmpfs,
+    # teslapy cache_file -> /data) is tracked for the uv modernization PR.
+    read_only: false
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -212,7 +212,7 @@ docker buildx build --platform linux/amd64,linux/arm64 -t teslaontarget:latest .
 1. **Local Network Only**: v1.0 uses plaintext TCP - run on same network as TAK server
 2. **Use Secrets**: For production, use Docker secrets instead of environment variables
 3. **Network Isolation**: Put TAK server and TeslaOnTarget on same Docker network
-4. **Read-only Root**: Add `read_only: true` to docker-compose.yml
+4. **Read-only Root**: Not currently supported — the entrypoint generates `/app/config.py` and creates cache symlinks under `/app` at startup, so the root filesystem must be writable (`read_only: false`). Hardened read-only mode (config written to a tmpfs path, teslapy's `cache_file` pointed at `/data`) is planned; until then do **not** set `read_only: true` or the container will crash-loop on startup.
 5. **Non-root User**: Container runs as non-root user by default
 6. **No WAN Exposure**: Do not expose TAK ports across Internet without VPN
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / test dependencies.
+#   pip install -r requirements.txt -r requirements-dev.txt
+pytest>=8.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-teslapy>=2.8.0
+# teslapy 2.9.2+ adds the TLS 1.3 TLSAdapter required since 2026-06-12, when
+# Tesla's Owner API began rejecting non-TLS-1.3 clients with HTTP 403
+# ("forbidden, see .../fleet-api"). Older teslapy (<=2.9.0) is permanently broken.
+teslapy>=2.9.2
 requests>=2.31.0

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -22,11 +22,14 @@ def _https_min_tls(tesla):
     both shapes so the test tracks intent, not implementation detail.
     """
     adapter = tesla.get_adapter("https://owner-api.teslamotors.com/")
-    kw = adapter.poolmanager.connection_pool_kw
+    # Stay defensive about teslapy's adapter internals: if the structure changes,
+    # return None so the assertion fails with its intended message rather than a
+    # bare AttributeError/KeyError.
+    pool_manager = getattr(adapter, "poolmanager", None)
+    kw = getattr(pool_manager, "connection_pool_kw", None) or {}
     if kw.get("ssl_minimum_version") is not None:
         return kw["ssl_minimum_version"]
-    ctx = kw.get("ssl_context")
-    return ctx.minimum_version if ctx is not None else None
+    return getattr(kw.get("ssl_context"), "minimum_version", None)
 
 
 def test_teslapy_ships_tls_adapter():

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,48 @@
+"""Regression test for the 2026-06-12 Tesla Owner API outage.
+
+On 2026-06-12 Tesla's Owner API began returning HTTP 403 ("forbidden, see
+.../fleet-api") to any client that did not negotiate TLS 1.3. teslapy 2.9.2
+fixed this by mounting a ``TLSAdapter`` that pins the connection to TLS 1.3.
+
+These tests fail loudly if a future dependency change drops teslapy below 2.9.2
+or otherwise stops enforcing TLS 1.3 -- instead of the bridge silently
+403-crash-looping in production again (which is exactly what happened, undetected,
+for two weeks).
+"""
+import ssl
+
+import teslapy
+
+
+def _https_min_tls(tesla):
+    """The minimum TLS version the teslapy session will negotiate for HTTPS.
+
+    teslapy 2.9.2 enforces this via urllib3's ``ssl_minimum_version`` pool kwarg
+    on its ``TLSAdapter`` (older builds used a pinned ``ssl_context``); support
+    both shapes so the test tracks intent, not implementation detail.
+    """
+    adapter = tesla.get_adapter("https://owner-api.teslamotors.com/")
+    kw = adapter.poolmanager.connection_pool_kw
+    if kw.get("ssl_minimum_version") is not None:
+        return kw["ssl_minimum_version"]
+    ctx = kw.get("ssl_context")
+    return ctx.minimum_version if ctx is not None else None
+
+
+def test_teslapy_ships_tls_adapter():
+    assert hasattr(teslapy, "TLSAdapter"), (
+        "teslapy is missing TLSAdapter (requires >=2.9.2); "
+        "Tesla Owner API will reject every request with HTTP 403"
+    )
+
+
+def test_https_requests_pin_tls_1_3():
+    tesla = teslapy.Tesla("regression@example.com")
+    try:
+        min_tls = _https_min_tls(tesla)
+        assert min_tls == ssl.TLSVersion.TLSv1_3, (
+            f"teslapy https adapter negotiates down to {min_tls!r}; "
+            "Tesla Owner API requires TLS 1.3 since 2026-06-12"
+        )
+    finally:
+        tesla.close()


### PR DESCRIPTION
## Problem
Since **2026-06-12**, Tesla's Owner API rejects any client that does not negotiate **TLS 1.3** with `403 forbidden, see .../fleet-api`. The old floor (`teslapy>=2.8.0`, resolving to 2.9.0) has no TLS 1.3 enforcement, so TeslaOnTarget 403-crash-looped — undetected — for ~2 weeks (last good CoT 2026-06-12 17:01).

This is **not** an Owner API shutdown or a Fleet API requirement — Owner API still works over TLS 1.3.

## Fix
- `requirements.txt`: `teslapy>=2.8.0` → **`teslapy>=2.9.2`** (PyPI 2.9.2 ships the `TLSAdapter` that pins TLS 1.3 via urllib3 `ssl_minimum_version`).
- `docker-compose.yml`: `read_only: true` → `false`. The entrypoint writes `config.py` and cache symlinks into `/app`; the rebuild exposed that this is incompatible with the read-only rootfs. Hardened read-only (config → tmpfs, teslapy `cache_file` → `/data`) is tracked for the uv-modernization PR.
- `tests/test_tls.py`: **regression test** asserting the teslapy session negotiates TLS 1.3 — fails loudly if a future dep bump drops the fix, instead of silently 403-looping.

## Verification
Deployed to the production container (CT138): `RestartCount=0`, `Health=healthy`, live vehicle data, `Successfully sent CoT packet for Tron` every 10s, **zero 403s**.

Follow-up PR: pip→uv modernization, Python 3.14, Dependabot PRs #22/#23/#24, hardened read-only, and a fuller test suite.