### PR TITLE
test: 100% coverage with mutation + property tests; decompose complex functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ teslaontarget_live.log
 
 # uv / virtualenv
 .venv/
+
+# mutation testing sandboxes
+mutants/
+.mutmut-cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,13 @@ packages = ["teslaontarget"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.mutmut]
+# Whole package (mutmut needs the full package importable). Mutation results are
+# only meaningful for modules with a mature test net; survivors in
+# not-yet-covered modules are expected until their coverage lands.
+paths_to_mutate = ["teslaontarget/"]
+tests_dir = ["tests/"]
+
 [tool.coverage.run]
 branch = true
 source = ["teslaontarget"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,13 @@ tesla-auth = "teslaontarget.auth:main"
 
 # PEP 735 dependency group; installed by `uv sync`, excluded by `uv sync --no-dev`.
 [dependency-groups]
-dev = ["pytest>=8.0.0", "flake8>=7.0.0"]
+dev = [
+    "pytest>=8.0.0",
+    "flake8>=7.0.0",
+    "pytest-cov>=5.0.0",
+    "hypothesis>=6.0.0",
+    "mutmut>=3.0.0",
+]
 
 [build-system]
 requires = ["hatchling"]
@@ -46,3 +52,14 @@ packages = ["teslaontarget"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["teslaontarget"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]

--- a/scripts/mutation_check.py
+++ b/scripts/mutation_check.py
@@ -100,6 +100,10 @@ MUTATIONS = [
     ("teslaontarget/tesla_api.py", 'uid = f"TESLA-{hashlib.md5(str(vehicle_id).encode()).hexdigest()[:8]}"',
      'uid = f"TESLA-{hashlib.md5(str(vehicle_id).encode()).hexdigest()[:7]}"',
      "tests/test_tesla_api.py", "tesla: UID md5 slice [:8] -> [:7]"),
+    ("teslaontarget/tesla_api.py",
+     "return data.get('latitude') is not None and data.get('longitude') is not None",
+     "return data.get('latitude') is None and data.get('longitude') is not None",
+     "tests/test_tesla_api.py", "tesla: _has_coordinates is-not-None -> is-None"),
 ]
 
 

--- a/scripts/mutation_check.py
+++ b/scripts/mutation_check.py
@@ -14,9 +14,14 @@ Exit 0 if all mutants are killed; exit 1 (and lists survivors) otherwise.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+# Never write .pyc while mutating: the mutate->import->revert cycle can finish
+# within one mtime tick, leaving a stale *mutated* .pyc that later imports reuse.
+_ENV = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -98,7 +103,7 @@ def run() -> int:
             result = subprocess.run(
                 ["uv", "run", "pytest", test, "-q", "--no-header",
                  "-p", "no:cacheprovider"],
-                cwd=ROOT, capture_output=True, text=True, timeout=180,
+                cwd=ROOT, capture_output=True, text=True, timeout=180, env=_ENV,
             )
             killed = result.returncode != 0
         finally:

--- a/scripts/mutation_check.py
+++ b/scripts/mutation_check.py
@@ -86,6 +86,20 @@ MUTATIONS = [
     ("teslaontarget/health.py", "self.hard_restart_seconds = hard_restart_seconds or (max_no_send_seconds * 5)",
      "self.hard_restart_seconds = hard_restart_seconds or (max_no_send_seconds * 4)",
      "tests/test_health.py", "health: hard-restart default *5 -> *4"),
+
+    # ---- tesla_api.py ----
+    ("teslaontarget/tesla_api.py", "self.rate_limit_backoff = min(self.rate_limit_backoff * 2, 32)",
+     "self.rate_limit_backoff = min(self.rate_limit_backoff * 1, 32)",
+     "tests/test_tesla_api.py", "tesla: rate-limit backoff *2 -> *1"),
+    ("teslaontarget/tesla_api.py", "if self.consecutive_errors >= 3:",
+     "if self.consecutive_errors > 3:",
+     "tests/test_tesla_api.py", "tesla: error escalation >=3 -> >3"),
+    ('teslaontarget/tesla_api.py', 'if "vehicle unavailable" in error_str or "asleep" in error_str:',
+     'if "vehicle unavailable" in error_str and "asleep" in error_str:',
+     "tests/test_tesla_api.py", "tesla: unavailable classify or -> and"),
+    ("teslaontarget/tesla_api.py", 'uid = f"TESLA-{hashlib.md5(str(vehicle_id).encode()).hexdigest()[:8]}"',
+     'uid = f"TESLA-{hashlib.md5(str(vehicle_id).encode()).hexdigest()[:7]}"',
+     "tests/test_tesla_api.py", "tesla: UID md5 slice [:8] -> [:7]"),
 ]
 
 

--- a/scripts/mutation_check.py
+++ b/scripts/mutation_check.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Deterministic mutation-testing harness for TeslaOnTarget.
+
+Why this exists instead of mutmut: mutmut 3.x does not route test imports to its
+mutated `mutants/` copy in this uv/installed-package setup, so it reports every
+mutant as "survived" even though the suite demonstrably kills mutations. This
+harness applies a curated set of *meaningful* source mutations to the real
+package, runs the test suite, and asserts each mutation is caught (a failing
+test == a killed mutant). A surviving mutant means the test net is too weak for
+that behavior and must be strengthened.
+
+Usage:  uv run python scripts/mutation_check.py
+Exit 0 if all mutants are killed; exit 1 (and lists survivors) otherwise.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# (module, original_snippet, mutated_snippet, test_target, description)
+MUTATIONS = [
+    # ---- utils.py ----
+    ("teslaontarget/utils.py", "return R * c", "return R + c",
+     "tests/test_utils.py", "distance: R*c -> R+c"),
+    ("teslaontarget/utils.py", "c = 2 * atan2", "c = 1 * atan2",
+     "tests/test_utils.py", "distance: 2*atan2 -> 1*atan2"),
+    ("teslaontarget/utils.py", "return mph * 0.44704 if mph else 0",
+     "return mph * 0.44704 if not mph else 0",
+     "tests/test_utils.py", "mph_to_ms: guard negation"),
+    ("teslaontarget/utils.py", "return mph * 0.44704 if mph else 0",
+     "return mph * 0.5 if mph else 0",
+     "tests/test_utils.py", "mph_to_ms: constant 0.44704 -> 0.5"),
+    ("teslaontarget/utils.py", "return (celsius * 9/5) + 32 if celsius is not None else None",
+     "return (celsius * 9/5) - 32 if celsius is not None else None",
+     "tests/test_utils.py", "c_to_f: +32 -> -32"),
+    ("teslaontarget/utils.py", "return meters * 3.28084", "return meters * 3.5",
+     "tests/test_utils.py", "meters_to_feet: constant"),
+
+    # ---- cot.py ----
+    ("teslaontarget/cot.py", "if speed and speed > 1:", "if speed and speed > 1000:",
+     "tests/test_cot.py", "cot: moving-speed threshold 1 -> 1000"),
+    ("teslaontarget/cot.py", 'ce = "5.0"  # Better accuracy', 'ce = "12.5"  # Better accuracy',
+     "tests/test_cot.py", "cot: moving CE 5.0 -> 12.5"),
+    ("teslaontarget/cot.py", "speed_ms = speed_mph * 0.44704", "speed_ms = speed_mph * 0.5",
+     "tests/test_cot.py", "cot: track speed conversion constant"),
+    ("teslaontarget/cot.py", "stale = now + timedelta(minutes=5)", "stale = now + timedelta(minutes=4)",
+     "tests/test_cot.py", "cot: stale window 5 -> 4 min"),
+    ("teslaontarget/cot.py", 'if charge_state in ["Disconnected", "Complete", None]:',
+     'if charge_state not in ["Disconnected", "Complete", None]:',
+     "tests/test_cot.py", "cot: charging guard inverted"),
+    ("teslaontarget/cot.py", "if not (shift_state == \"P\" or shift_state is None):",
+     "if (shift_state == \"P\" or shift_state is None):",
+     "tests/test_cot.py", "cot: security guard inverted"),
+
+    # ---- config_handler.py ----
+    ("teslaontarget/config_handler.py", "if not cls.TESLA_USERNAME:",
+     "if cls.TESLA_USERNAME:",
+     "tests/test_config_handler.py", "config: username validation inverted"),
+    ("teslaontarget/config_handler.py", "if os.path.isfile(env_path):",
+     "if not os.path.isfile(env_path):",
+     "tests/test_config_handler.py", "config: env isfile inverted"),
+
+    # ---- tak_client.py ----
+    ("teslaontarget/tak_client.py", "self.connected = True\n            self.last_connect_ok",
+     "self.connected = False\n            self.last_connect_ok",
+     "tests/test_tak_client.py", "tak: connect leaves connected False"),
+    ("teslaontarget/tak_client.py", "self.last_send_ok = time.time()\n                return True",
+     "self.last_send_ok = time.time()\n                return False",
+     "tests/test_tak_client.py", "tak: send_cot returns False on success"),
+
+    # ---- health.py ----
+    ("teslaontarget/health.py", "return max(0, int(now - last_ok))",
+     "return max(0, int(now + last_ok))",
+     "tests/test_health.py", "health: staleness now-last -> now+last"),
+    ("teslaontarget/health.py", "if stale_for is not None and stale_for > self.max_no_send_seconds:",
+     "if stale_for is not None and stale_for < self.max_no_send_seconds:",
+     "tests/test_health.py", "health: stale comparison flipped"),
+    ("teslaontarget/health.py", "self.hard_restart_seconds = hard_restart_seconds or (max_no_send_seconds * 5)",
+     "self.hard_restart_seconds = hard_restart_seconds or (max_no_send_seconds * 4)",
+     "tests/test_health.py", "health: hard-restart default *5 -> *4"),
+]
+
+
+def run() -> int:
+    survivors = []
+    for module, old, new, test, desc in MUTATIONS:
+        path = ROOT / module
+        original = path.read_text()
+        if old not in original:
+            print(f"  [ERROR ] anchor missing, cannot mutate: {desc}")
+            survivors.append(desc + " (anchor missing)")
+            continue
+        path.write_text(original.replace(old, new, 1))
+        try:
+            result = subprocess.run(
+                ["uv", "run", "pytest", test, "-q", "--no-header",
+                 "-p", "no:cacheprovider"],
+                cwd=ROOT, capture_output=True, text=True, timeout=180,
+            )
+            killed = result.returncode != 0
+        finally:
+            path.write_text(original)  # always restore
+        print(f"  [{'KILLED' if killed else 'SURVIVED'}] {desc}")
+        if not killed:
+            survivors.append(desc)
+
+    total = len(MUTATIONS)
+    print(f"\nMutation result: {total - len(survivors)}/{total} killed")
+    if survivors:
+        print("SURVIVORS (strengthen these tests):")
+        for s in survivors:
+            print(f"  - {s}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/teslaontarget/cli.py
+++ b/teslaontarget/cli.py
@@ -1,45 +1,49 @@
 """Command line interface for TeslaOnTarget."""
 
+import os
 import sys
 import time
 import signal
 import logging
 import argparse
 import threading
+
 from teslapy import Tesla
 
 from .tesla_api import TeslaCoT
+from .tak_client import TAKClient
 from .config_handler import Config
 from .health import HealthMonitor
 
-# Set up logging
-import os
-
-# Determine log file path - use /logs if available (Docker), otherwise current directory
-log_handlers = [logging.StreamHandler()]  # Always log to stdout
-
-# Try to add file handler
-try:
-    if os.path.exists('/logs') and os.access('/logs', os.W_OK):
-        log_path = '/logs/teslaontarget.log'
-    else:
-        log_path = 'teslaontarget.log'
-    
-    file_handler = logging.FileHandler(log_path)
-    log_handlers.append(file_handler)
-except (IOError, OSError) as e:
-    # If we can't write to file, just use stdout
-    print(f"Warning: Unable to create log file: {e}. Logging to stdout only.")
-
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=log_handlers
-)
 logger = logging.getLogger(__name__)
 
-# Global variable for graceful shutdown
+# Global flag for graceful shutdown (flipped by the signal handler).
 running = True
+
+
+def _make_log_handlers():
+    """Build logging handlers: always stdout, plus a file handler when writable."""
+    handlers = [logging.StreamHandler()]
+    try:
+        if os.path.exists('/logs') and os.access('/logs', os.W_OK):
+            log_path = '/logs/teslaontarget.log'
+        else:
+            log_path = 'teslaontarget.log'
+        handlers.append(logging.FileHandler(log_path))
+    except (IOError, OSError) as e:
+        print(f"Warning: Unable to create log file: {e}. Logging to stdout only.")
+    return handlers
+
+
+def _configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        handlers=_make_log_handlers(),
+    )
+
+
+_configure_logging()
 
 
 def signal_handler(sig, frame):
@@ -49,139 +53,135 @@ def signal_handler(sig, frame):
     running = False
 
 
-def main():
-    """Main entry point for TeslaOnTarget."""
+def _parse_args():
     parser = argparse.ArgumentParser(description='Bridge Tesla vehicles with TAK servers')
     parser.add_argument('--config', help='Path to config.py file')
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
-    args = parser.parse_args()
-    
-    # Set debug logging if requested
+    return parser.parse_args()
+
+
+def _load_and_validate_config(args):
+    """Apply --debug, load config, and exit(1) if it does not validate."""
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
-    
-    # Load configuration
     Config.load_from_file(args.config)
-    
-    # Validate configuration
     if not Config.validate():
         logger.error("Invalid configuration. Please check config.py")
         sys.exit(1)
-    
-    # Set up signal handlers
+
+
+def _select_vehicles(tesla):
+    """Return vehicles to track, applying VEHICLE_FILTER. Exits if none."""
+    vehicles = tesla.vehicle_list()
+    if not vehicles:
+        logger.error("No vehicles found on Tesla account")
+        sys.exit(1)
+    logger.info(f"Found {len(vehicles)} vehicle(s) on account")
+
+    vehicle_filter = getattr(Config, 'VEHICLE_FILTER', [])
+    if not vehicle_filter:
+        logger.info("No vehicle filter configured - tracking all vehicles")
+        return vehicles
+
+    filtered = []
+    for vehicle in vehicles:
+        display_name = vehicle.get('display_name', '')
+        vin = vehicle.get('vin', '')
+        if display_name in vehicle_filter or vin in vehicle_filter:
+            filtered.append(vehicle)
+            logger.info(f"Selected vehicle: {display_name} (VIN: {vin})")
+    if not filtered:
+        logger.error(f"No vehicles matched the filter: {vehicle_filter}")
+        sys.exit(1)
+    logger.info(f"Tracking {len(filtered)} vehicle(s) based on filter")
+    return filtered
+
+
+def _build_health_monitor(tak_client):
+    """Construct a HealthMonitor from Config, treating <=0 thresholds as unset."""
+    configured_no_send = getattr(Config, 'HEALTH_NO_SEND_SECONDS', 0) or 0
+    configured_check = getattr(Config, 'HEALTH_CHECK_INTERVAL', 0) or 0
+    configured_hard = getattr(Config, 'HEALTH_HARD_RESTART_SECONDS', 0) or 0
+    health_file = getattr(Config, 'HEALTH_FILE', 'health.json')
+
+    default_no_send = max(120, Config.API_LOOP_DELAY * 8)
+    max_no_send = configured_no_send if configured_no_send > 0 else default_no_send
+    check_interval = configured_check if configured_check > 0 else 15
+    hard_restart = configured_hard if configured_hard > 0 else (max_no_send * 5)
+
+    logger.info(
+        "Health thresholds: no-send=%ss, check=%ss, hard-restart=%ss -> file=%s",
+        max_no_send, check_interval, hard_restart, health_file,
+    )
+    return HealthMonitor(
+        tak_client, health_file=health_file, max_no_send_seconds=max_no_send,
+        check_interval=check_interval, hard_restart_seconds=hard_restart,
+    )
+
+
+def _wake_vehicles(vehicles):
+    """Send a wake command to any asleep vehicle (best-effort)."""
+    logger.info("Waking up vehicles...")
+    for vehicle in vehicles:
+        try:
+            if vehicle.get("state") == "asleep":
+                logger.info(f"Waking up {vehicle['display_name']}...")
+                vehicle.sync_wake_up()
+        except Exception as e:
+            logger.warning(f"Could not wake {vehicle['display_name']}: {e}")
+
+
+def _start_tracking_threads(vehicles, tak_client):
+    """Spawn one daemon tracking thread per vehicle; return the thread list."""
+    threads = []
+    for vehicle in vehicles:
+        vehicle_id = vehicle.get('vin', vehicle.get('id_s', 'unknown'))
+        tesla_cot = TeslaCoT(vehicle_id=vehicle_id, tak_client=tak_client)
+        logger.info(f"Starting tracking for {vehicle['display_name']} (VIN: {vehicle.get('vin', 'N/A')})")
+        thread = threading.Thread(
+            target=tesla_cot.fetch_and_send_data_for_vehicle,
+            args=(vehicle,), daemon=True,
+            name=f"Vehicle-{vehicle['display_name']}",
+        )
+        thread.start()
+        threads.append(thread)
+    return threads
+
+
+def _monitor_threads(threads):
+    """Watch tracking threads until shutdown is requested."""
+    logger.info("All tracking threads started")
+    logger.info(f"Sending updates every {Config.API_LOOP_DELAY} seconds")
+    logger.info("Press Ctrl+C to stop\n")
+    while running:
+        alive_count = sum(1 for t in threads if t.is_alive())
+        if alive_count < len(threads):
+            logger.warning(f"Only {alive_count}/{len(threads)} threads running")
+        time.sleep(5)
+
+
+def main():
+    """Main entry point for TeslaOnTarget."""
+    args = _parse_args()
+    _load_and_validate_config(args)
+
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
-    
     logger.info("Starting TeslaOnTarget...")
-    
+
+    health = None
     try:
-        # Initialize Tesla API
         tesla = Tesla(Config.TESLA_USERNAME)
-        
-        # Get vehicles
-        vehicles = tesla.vehicle_list()
-        if not vehicles:
-            logger.error("No vehicles found on Tesla account")
-            sys.exit(1)
-            
-        logger.info(f"Found {len(vehicles)} vehicle(s) on account")
-        
-        # Filter vehicles if configured
-        vehicle_filter = getattr(Config, 'VEHICLE_FILTER', [])
-        if vehicle_filter:
-            filtered_vehicles = []
-            for vehicle in vehicles:
-                display_name = vehicle.get('display_name', '')
-                vin = vehicle.get('vin', '')
-                if display_name in vehicle_filter or vin in vehicle_filter:
-                    filtered_vehicles.append(vehicle)
-                    logger.info(f"Selected vehicle: {display_name} (VIN: {vin})")
-            
-            if not filtered_vehicles:
-                logger.error(f"No vehicles matched the filter: {vehicle_filter}")
-                sys.exit(1)
-            
-            vehicles = filtered_vehicles
-            logger.info(f"Tracking {len(vehicles)} vehicle(s) based on filter")
-        else:
-            logger.info("No vehicle filter configured - tracking all vehicles")
-        
-        # Create shared TAK client for all vehicles
-        from .tak_client import TAKClient
+        vehicles = _select_vehicles(tesla)
+
         shared_tak_client = TAKClient(Config.COT_URL)
 
-        # Start health monitor watching TAK sends
-        # docker-entrypoint may write HEALTH_* as 0 to indicate "use defaults".
-        # Treat <= 0 as unset and apply sane defaults.
-        configured_no_send = getattr(Config, 'HEALTH_NO_SEND_SECONDS', 0) or 0
-        configured_check = getattr(Config, 'HEALTH_CHECK_INTERVAL', 0) or 0
-        configured_hard = getattr(Config, 'HEALTH_HARD_RESTART_SECONDS', 0) or 0
-        health_file = getattr(Config, 'HEALTH_FILE', 'health.json')
-
-        # Defaults scale with API loop delay
-        default_no_send = max(120, Config.API_LOOP_DELAY * 8)
-        default_check = 15
-
-        max_no_send = configured_no_send if configured_no_send > 0 else default_no_send
-        check_interval = configured_check if configured_check > 0 else default_check
-        hard_restart = configured_hard if configured_hard > 0 else (max_no_send * 5)
-
-        logger.info(
-            "Health thresholds: no-send=%ss, check=%ss, hard-restart=%ss -> file=%s",
-            max_no_send,
-            check_interval,
-            hard_restart,
-            health_file,
-        )
-        health = HealthMonitor(
-            shared_tak_client,
-            health_file=health_file,
-            max_no_send_seconds=max_no_send,
-            check_interval=check_interval,
-            hard_restart_seconds=hard_restart,
-        )
+        health = _build_health_monitor(shared_tak_client)
         health.start()
-        
-        # Create threads for each vehicle
-        threads = []
-        
-        # Wake vehicles if needed
-        logger.info("Waking up vehicles...")
-        for vehicle in vehicles:
-            try:
-                if vehicle.get("state") == "asleep":
-                    logger.info(f"Waking up {vehicle['display_name']}...")
-                    vehicle.sync_wake_up()
-            except Exception as e:
-                logger.warning(f"Could not wake {vehicle['display_name']}: {e}")
-        
-        # Start tracking threads
-        for vehicle in vehicles:
-            # Create a separate TeslaCoT instance for each vehicle
-            vehicle_id = vehicle.get('vin', vehicle.get('id_s', 'unknown'))
-            tesla_cot = TeslaCoT(vehicle_id=vehicle_id, tak_client=shared_tak_client)
-            
-            logger.info(f"Starting tracking for {vehicle['display_name']} (VIN: {vehicle.get('vin', 'N/A')})")
-            thread = threading.Thread(
-                target=tesla_cot.fetch_and_send_data_for_vehicle,
-                args=(vehicle,),
-                daemon=True,
-                name=f"Vehicle-{vehicle['display_name']}"
-            )
-            thread.start()
-            threads.append(thread)
-            
-        logger.info("All tracking threads started")
-        logger.info(f"Sending updates every {Config.API_LOOP_DELAY} seconds")
-        logger.info("Press Ctrl+C to stop\n")
-        
-        # Monitor threads
-        while running:
-            alive_count = sum(1 for t in threads if t.is_alive())
-            if alive_count < len(threads):
-                logger.warning(f"Only {alive_count}/{len(threads)} threads running")
-            time.sleep(5)
-            
+
+        _wake_vehicles(vehicles)
+        threads = _start_tracking_threads(vehicles, shared_tak_client)
+        _monitor_threads(threads)
     except KeyboardInterrupt:
         logger.info("Interrupted by user")
     except Exception as e:
@@ -190,10 +190,11 @@ def main():
     finally:
         logger.info("TeslaOnTarget stopped")
         try:
-            health.stop()
+            if health:
+                health.stop()
         except Exception:
             pass
-        
-        
+
+
 if __name__ == '__main__':
     main()

--- a/teslaontarget/config_handler.py
+++ b/teslaontarget/config_handler.py
@@ -19,12 +19,8 @@ class Config:
     MPH_TO_MS = 0.44704
     
     @classmethod
-    def load_from_file(cls, config_path=None):
-        """Load configuration from Python file.
-        
-        Args:
-            config_path: Path to config.py file
-        """
+    def _resolve_config_path(cls, config_path):
+        """Resolve the config path to use (explicit arg > env var > package-adjacent)."""
         if config_path is None:
             # Prefer an explicit path (set by the container) so config loading
             # never depends on where the package happens to be installed. Only
@@ -34,13 +30,20 @@ class Config:
             if env_path:
                 env_path = os.path.expanduser(env_path)
                 if os.path.isfile(env_path):
-                    config_path = env_path
-        if config_path is None:
+                    return env_path
             # Fall back to config.py next to the package
             parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
             config_path = os.path.join(parent_dir, 'config.py')
+        return os.path.expanduser(config_path)
 
-        config_path = os.path.expanduser(config_path)
+    @classmethod
+    def load_from_file(cls, config_path=None):
+        """Load configuration from a Python file.
+
+        Args:
+            config_path: Path to config.py file
+        """
+        config_path = cls._resolve_config_path(config_path)
         if not os.path.isfile(config_path):
             logger.warning(f"Config file not found at {config_path}, using defaults")
             return

--- a/teslaontarget/cot.py
+++ b/teslaontarget/cot.py
@@ -65,14 +65,15 @@ def _security_remark(data, shift_state):
     locked = data.get("locked")
     if locked is not None:
         text += f" | Doors: {'Locked' if locked else 'Unlocked'}"
+    # `or 0` guards against Tesla returning null for these fields (None > 0 raises).
     windows_open = [label for key, label in (
         ("fd_window", "FD"), ("fp_window", "FP"),
-        ("rd_window", "RD"), ("rp_window", "RP")) if data.get(key, 0) > 0]
+        ("rd_window", "RD"), ("rp_window", "RP")) if (data.get(key) or 0) > 0]
     if windows_open:
         text += f" | WINDOWS OPEN: {','.join(windows_open)}"
-    if data.get("ft", 0) > 0:
+    if (data.get("ft") or 0) > 0:
         text += " | FRUNK OPEN"
-    if data.get("rt", 0) > 0:
+    if (data.get("rt") or 0) > 0:
         text += " | TRUNK OPEN"
     return text
 

--- a/teslaontarget/cot.py
+++ b/teslaontarget/cot.py
@@ -15,6 +15,84 @@ def celsius_to_fahrenheit(celsius):
     return (celsius * 9/5) + 32
 
 
+def _charging_time_remark(data):
+    """Return the ' (Xh Ym to Z%)' charging-time fragment, or '' if unknown."""
+    charge_limit_soc = data.get("charge_limit_soc", 80)
+    minutes_to_full = data.get("minutes_to_full_charge", 0)
+    time_to_full = data.get("time_to_full_charge", 0)
+    if minutes_to_full and minutes_to_full > 0:
+        hours = int(minutes_to_full // 60)
+        mins = int(minutes_to_full % 60)
+        if hours > 0:
+            return f" ({hours}h {mins}m to {charge_limit_soc}%)"
+        return f" ({mins}m to {charge_limit_soc}%)"
+    if time_to_full and time_to_full > 0:
+        if time_to_full >= 1:
+            return f" ({time_to_full:.1f}h to {charge_limit_soc}%)"
+        mins = int(time_to_full * 60)
+        return f" ({mins}m to {charge_limit_soc}%)"
+    return ""
+
+
+def _charging_remark(data):
+    """Return the ' | <state> ...' charging fragment, or '' when not charging."""
+    charge_state = data.get("charging_state", "Disconnected")
+    if charge_state in ["Disconnected", "Complete", None]:
+        return ""
+    text = f" | {charge_state}" + _charging_time_remark(data)
+    if data.get("charge_port_door_open", False):
+        text += " Port Open"
+    return text
+
+
+def _autopilot_remark(data, shift_state):
+    """Return the autopilot/FSD fragment, only meaningful while driving."""
+    autopilot_state = data.get("autopilot_state", 0)
+    if shift_state not in ["D", "R"] or not autopilot_state:
+        return ""
+    return {
+        2: " | AUTOPILOT ACTIVE",
+        3: " | FSD ACTIVE",
+        1: " | AUTOPILOT AVAILABLE",
+    }.get(autopilot_state, "")
+
+
+def _security_remark(data, shift_state):
+    """Return the parked security fragment (sentry/doors/windows/trunks)."""
+    if not (shift_state == "P" or shift_state is None):
+        return ""
+    text = f" | Sentry: {'ON' if data.get('sentry_mode', False) else 'OFF'}"
+    locked = data.get("locked")
+    if locked is not None:
+        text += f" | Doors: {'Locked' if locked else 'Unlocked'}"
+    windows_open = [label for key, label in (
+        ("fd_window", "FD"), ("fp_window", "FP"),
+        ("rd_window", "RD"), ("rp_window", "RP")) if data.get(key, 0) > 0]
+    if windows_open:
+        text += f" | WINDOWS OPEN: {','.join(windows_open)}"
+    if data.get("ft", 0) > 0:
+        text += " | FRUNK OPEN"
+    if data.get("rt", 0) > 0:
+        text += " | TRUNK OPEN"
+    return text
+
+
+def _build_remarks(data):
+    """Build the single-line CoT remarks string from vehicle data."""
+    shift_state = data.get("shift_state", "P")
+    remarks_text = f"Tesla {data.get('vehicle_model', 'Vehicle')}"
+    remarks_text += f" | Gear: {shift_state}" if shift_state else " | Gear: P"
+    battery_range = data.get("battery_range")
+    if battery_range is not None:
+        remarks_text += f" | Range: {battery_range:.0f} mi"
+    remarks_text += _charging_remark(data)
+    remarks_text += _autopilot_remark(data, shift_state)
+    if data.get("is_climate_on", False):
+        remarks_text += " | Climate: ON"
+    remarks_text += _security_remark(data, shift_state)
+    return remarks_text
+
+
 def generate_cot_packet(data):
     """Generate a Cursor on Target (CoT) XML packet from vehicle data.
     
@@ -114,98 +192,8 @@ def generate_cot_packet(data):
     
     # Add remarks with Tesla-specific info
     remarks = ET.SubElement(detail, "remarks")
-    charge_state = data.get("charging_state", "Disconnected")
-    sentry_mode = data.get("sentry_mode", False)
-    locked = data.get("locked")
-    shift_state = data.get("shift_state", "P")
-    battery_range = data.get("battery_range")
-    is_climate_on = data.get("is_climate_on", False)
-    charge_port_open = data.get("charge_port_door_open", False)
-    
-    # Check for open windows/trunks
-    windows_open = []
-    if data.get("fd_window", 0) > 0: windows_open.append("FD")
-    if data.get("fp_window", 0) > 0: windows_open.append("FP")
-    if data.get("rd_window", 0) > 0: windows_open.append("RD")
-    if data.get("rp_window", 0) > 0: windows_open.append("RP")
-    
-    frunk_open = data.get("ft", 0) > 0
-    trunk_open = data.get("rt", 0) > 0
-    
-    # Autopilot/FSD status
-    autopilot_state = data.get("autopilot_state", 0)
-    autopilot_style = data.get("autopilot_style")
-    
-    # Build remarks as a single line with separators for TAK compatibility
-    remarks_text = f"Tesla {data.get('vehicle_model', 'Vehicle')}"
-    
-    # Always show gear state
-    if shift_state:
-        remarks_text += f" | Gear: {shift_state}"
-    else:
-        remarks_text += " | Gear: P"  # Default to Park if unknown
-    
-    # Show range if available
-    if battery_range is not None:
-        remarks_text += f" | Range: {battery_range:.0f} mi"
-    
-    # Show if actively charging with time remaining
-    if charge_state not in ["Disconnected", "Complete", None]:
-        remarks_text += f" | {charge_state}"
-        
-        # Get charging time info
-        charge_limit_soc = data.get("charge_limit_soc", 80)
-        minutes_to_full = data.get("minutes_to_full_charge", 0)
-        time_to_full = data.get("time_to_full_charge", 0)
-        
-        # Show time to charge limit
-        if minutes_to_full and minutes_to_full > 0:
-            hours = int(minutes_to_full // 60)
-            mins = int(minutes_to_full % 60)
-            if hours > 0:
-                remarks_text += f" ({hours}h {mins}m to {charge_limit_soc}%)"
-            else:
-                remarks_text += f" ({mins}m to {charge_limit_soc}%)"
-        elif time_to_full and time_to_full > 0:
-            # Fallback to hours if minutes not available
-            if time_to_full >= 1:
-                remarks_text += f" ({time_to_full:.1f}h to {charge_limit_soc}%)"
-            else:
-                mins = int(time_to_full * 60)
-                remarks_text += f" ({mins}m to {charge_limit_soc}%)"
-        
-        if charge_port_open:
-            remarks_text += " Port Open"
-    
-    # Show if Autopilot/FSD is engaged when driving
-    if shift_state in ["D", "R"] and autopilot_state:
-        if autopilot_state == 2:
-            remarks_text += " | AUTOPILOT ACTIVE"
-        elif autopilot_state == 3:
-            remarks_text += " | FSD ACTIVE"
-        elif autopilot_state == 1:
-            remarks_text += " | AUTOPILOT AVAILABLE"
-    
-    # Climate status - important to know if someone might be in vehicle
-    if is_climate_on:
-        remarks_text += " | Climate: ON"
-    
-    # Security info when parked
-    if shift_state == "P" or shift_state is None:
-        remarks_text += f" | Sentry: {'ON' if sentry_mode else 'OFF'}"
-        if locked is not None:
-            remarks_text += f" | Doors: {'Locked' if locked else 'Unlocked'}"
-        
-        # Alert for security concerns
-        if windows_open:
-            remarks_text += f" | WINDOWS OPEN: {','.join(windows_open)}"
-        if frunk_open:
-            remarks_text += " | FRUNK OPEN"
-        if trunk_open:
-            remarks_text += " | TRUNK OPEN"
-    
-    remarks.text = remarks_text
-    
+    remarks.text = _build_remarks(data)
+
     # Convert to string
     cot_xml = ET.tostring(root, encoding='unicode')
     

--- a/teslaontarget/health.py
+++ b/teslaontarget/health.py
@@ -63,57 +63,49 @@ class HealthMonitor:
         except Exception as e:
             logger.warning("Failed writing health file %s: %s", self.health_file, e)
 
+    def _staleness(self, now, last_ok):
+        """Seconds since the last successful send, or None if never sent."""
+        if last_ok is None:
+            return None
+        return max(0, int(now - last_ok))
+
+    def _check_once(self, now):
+        """Run a single health check: write the snapshot and react to staleness."""
+        snap = self.tak_client.health_snapshot() if hasattr(self.tak_client, "health_snapshot") else {}
+        stale_for = self._staleness(now, snap.get("last_send_ok"))
+
+        self._write_snapshot({
+            "time": now,
+            "connected": snap.get("connected"),
+            "tak": snap,
+            "stale_seconds": stale_for,
+            "threshold_seconds": self.max_no_send_seconds,
+        })
+
+        if stale_for is not None and stale_for > self.max_no_send_seconds:
+            logger.warning(
+                "No successful TAK send for %ss (> %ss). Forcing reconnect.",
+                stale_for, self.max_no_send_seconds,
+            )
+            try:
+                self.tak_client.disconnect()
+            except Exception:
+                pass
+            self.tak_client.start_background_reconnect()
+
+        if (stale_for is not None
+                and self.hard_restart_seconds is not None
+                and stale_for > self.hard_restart_seconds):
+            logger.error(
+                "Health critical: no TAK send for %ss (> %ss). Exiting for supervisor restart.",
+                stale_for, self.hard_restart_seconds,
+            )
+            # Exit the process to allow systemd/docker to restart it
+            os._exit(12)
+
     def _run(self):
         while not self._stop.is_set():
-            now = time.time()
-            snap = self.tak_client.health_snapshot() if hasattr(self.tak_client, "health_snapshot") else {}
-            last_ok = snap.get("last_send_ok")
-
-            # Compute staleness
-            stale_for = None
-            if last_ok is not None:
-                stale_for = max(0, int(now - last_ok))
-            else:
-                # Never sent yet; consider stale from process start
-                stale_for = None
-
-            # Write health file
-            snapshot = {
-                "time": now,
-                "connected": snap.get("connected"),
-                "tak": snap,
-                "stale_seconds": stale_for,
-                "threshold_seconds": self.max_no_send_seconds,
-            }
-            self._write_snapshot(snapshot)
-
-            # Act if stale
-            if stale_for is not None and stale_for > self.max_no_send_seconds:
-                logger.warning(
-                    "No successful TAK send for %ss (> %ss). Forcing reconnect.",
-                    stale_for,
-                    self.max_no_send_seconds,
-                )
-                try:
-                    self.tak_client.disconnect()
-                except Exception:
-                    pass
-                self.tak_client.start_background_reconnect()
-
-            # Escalate to hard restart if far beyond threshold
-            if (
-                stale_for is not None
-                and self.hard_restart_seconds is not None
-                and stale_for > self.hard_restart_seconds
-            ):
-                logger.error(
-                    "Health critical: no TAK send for %ss (> %ss). Exiting for supervisor restart.",
-                    stale_for,
-                    self.hard_restart_seconds,
-                )
-                # Exit the process to allow systemd/docker to restart it
-                os._exit(12)
-
+            self._check_once(time.time())
             # Sleep with stop awareness
             self._stop.wait(self.check_interval)
 

--- a/teslaontarget/tesla_api.py
+++ b/teslaontarget/tesla_api.py
@@ -21,6 +21,15 @@ from .utils import calculate_distance, save_json_file, load_json_file
 from .cot import generate_cot_packet, format_cot_for_tak
 from .tak_client import TAKClient
 
+# Tesla get_vehicle_data endpoint sets
+_INIT_ENDPOINTS = ('location_data;drive_state;charge_state;vehicle_state;'
+                   'climate_state;vehicle_config;gui_settings')
+_LOOP_ENDPOINTS = ('location_data;drive_state;charge_state;vehicle_state;'
+                   'climate_state;vehicle_config')
+# Substrings in an API error that mean "slow down" rather than "broken"
+_RATE_LIMIT_MARKERS = ('429', 'rate limit', 'too many requests', 'timeout')
+
+
 class TeslaCoT:
     def __init__(self, vehicle_id=None, tak_client=None):
         # Load configuration
@@ -45,6 +54,10 @@ class TeslaCoT:
         self.rate_limit_backoff = 1  # Multiplier for delays
         self.consecutive_errors = 0
         self.last_rate_limit_time = 0
+        self.max_wake_attempts = 3
+        # Loop state (promoted from locals so the loop body is testable)
+        self.consecutive_no_gps_count = 0
+        self.vehicle_woken_once = True
         
         # Debug mode - captures all Tesla API responses
         self.debug_mode = getattr(self.config, 'DEBUG_MODE', True)  # Default to True for now
@@ -302,220 +315,196 @@ class TeslaCoT:
             else:
                 logger.warning("No valid position for dead reckoning")
                 break
-    
-    def fetch_and_send_data_for_vehicle(self, vehicle):
-        """Main loop to fetch data from Tesla API and send to TAK."""
-        # Generate a hashed UID for the vehicle based on its VIN
-        vehicle_data = None
-        vehicle_id = None
-        wake_attempts = 0
-        max_wake_attempts = 3
-        
-        # Initial setup - try to get vehicle data
-        logger.info(f"Initializing tracking for {vehicle.get('display_name', 'Unknown')}...")
-        
-        # First check if vehicle is asleep
+
+    def _wake_if_asleep(self, vehicle):
+        """Send a wake command if the vehicle reports asleep (best-effort)."""
         if vehicle.get("state") == "asleep":
-            logger.info(f"Vehicle is asleep. Attempting to wake for initial position...")
+            logger.info("Vehicle is asleep. Attempting to wake for initial position...")
             try:
                 vehicle.sync_wake_up()
                 logger.info("Vehicle wake command sent, waiting for it to come online...")
-                time.sleep(5)  # Give it a moment to wake up
+                time.sleep(5)
             except Exception as e:
                 logger.warning(f"Failed to wake vehicle: {e}")
-        
-        # Now try to get vehicle data
-        while vehicle_data is None and wake_attempts < max_wake_attempts:
+
+    def _fetch_initial_data(self, vehicle):
+        """Retry get_vehicle_data up to max_wake_attempts; return data or None."""
+        attempts = 0
+        while attempts < self.max_wake_attempts:
             try:
-                # Tesla API now requires specific endpoints to get location data
-                # Using all available endpoints to capture complete data
-                vehicle_data = vehicle.get_vehicle_data(endpoints='location_data;drive_state;charge_state;vehicle_state;climate_state;vehicle_config;gui_settings')
-                vehicle_id = vehicle_data.get("vin", 
-                                             vehicle_data.get("vehicle_state", {}).get("vehicle_name"))
-                logger.info(f"Successfully got initial vehicle data")
-                
-                # Save debug capture of initial data
+                vehicle_data = vehicle.get_vehicle_data(endpoints=_INIT_ENDPOINTS)
+                logger.info("Successfully got initial vehicle data")
                 self.save_debug_capture(vehicle_data, "initial_vehicle_data")
+                return vehicle_data
             except Exception as e:
-                wake_attempts += 1
-                logger.warning(f"Failed to get vehicle data (attempt {wake_attempts}/{max_wake_attempts}): {e}")
-                if wake_attempts < max_wake_attempts:
-                    time.sleep(10)  # Wait before retry
-        
+                attempts += 1
+                logger.warning(f"Failed to get vehicle data (attempt {attempts}/{self.max_wake_attempts}): {e}")
+                if attempts < self.max_wake_attempts:
+                    time.sleep(10)
+        return None
+
+    def _seed_initial_position(self, vehicle):
+        """Acquire the first fix and seed last-known position.
+
+        Returns True if tracking should proceed, False if there is nothing to
+        work with (no fresh data and no cached position).
+        """
+        logger.info(f"Initializing tracking for {vehicle.get('display_name', 'Unknown')}...")
+        self._wake_if_asleep(vehicle)
+        vehicle_data = self._fetch_initial_data(vehicle)
         if vehicle_data is None:
-            logger.error(f"Failed to get initial vehicle data after {max_wake_attempts} attempts")
-            # Try to use cached position if available
+            logger.error(f"Failed to get initial vehicle data after {self.max_wake_attempts} attempts")
             if self.last_known_valid_data:
                 logger.info("Using cached position data")
-                vehicle_id = vehicle.get('vin', vehicle.get('id_s', 'unknown'))
-                # Send cached position immediately
+                self.send_to_cot(self.last_known_valid_data)
+                return True
+            logger.error(f"No cached data available for {vehicle.get('display_name', 'Unknown')}")
+            return False
+        initial_data = self.extract_relevant_data(vehicle_data, vehicle)
+        if initial_data.get('latitude') and initial_data.get('longitude'):
+            self.last_known_valid_data = initial_data
+            self.save_last_position_to_file(initial_data)
+            logger.info(f"Saved initial position: {initial_data.get('latitude')}, {initial_data.get('longitude')}")
+        return True
+
+    def _classify_api_error(self, error_str):
+        """Classify a (lowercased) API error string: rate_limit / unavailable / other."""
+        if any(marker in error_str for marker in _RATE_LIMIT_MARKERS):
+            return "rate_limit"
+        if "vehicle unavailable" in error_str or "asleep" in error_str:
+            return "unavailable"
+        return "other"
+
+    def _handle_api_error(self, exc):
+        """React to a get_vehicle_data failure; return seconds to sleep before retry."""
+        kind = self._classify_api_error(str(exc).lower())
+        if kind == "rate_limit":
+            self.consecutive_errors += 1
+            self.rate_limit_backoff = min(self.rate_limit_backoff * 2, 32)
+            self.last_rate_limit_time = time.time()
+            delay = self.config.API_LOOP_DELAY * self.rate_limit_backoff
+            logger.warning(f"Rate limit detected! Backing off to {delay}s delay (error #{self.consecutive_errors})")
+            logger.warning(f"Error details: {exc}")
+            if self.last_known_valid_data:
+                self.send_to_cot(self.last_known_valid_data)
+            return delay
+        if kind == "unavailable":
+            logger.info("Vehicle is asleep/unavailable. Using last known position.")
+            if self.last_known_valid_data:
                 self.send_to_cot(self.last_known_valid_data)
             else:
-                logger.error(f"No cached data available for {vehicle.get('display_name', 'Unknown')}")
-                return
+                logger.warning("No last known position available")
+            return self.config.API_LOOP_DELAY
+        # other
+        self.consecutive_errors += 1
+        logger.error(f"API error (#{self.consecutive_errors}): {exc}")
+        if self.consecutive_errors >= 3:
+            self.rate_limit_backoff = min(self.rate_limit_backoff * 1.5, 16)
+            delay = self.config.API_LOOP_DELAY * self.rate_limit_backoff
+            logger.warning(f"Multiple API errors detected. Backing off to {delay}s delay")
+            return delay
+        return self.config.API_LOOP_DELAY
+
+    def _start_dead_reckoning(self, data):
+        """(Re)start the dead-reckoning thread for the given position, if moving."""
+        if self.dead_reckoning_thread and self.dead_reckoning_thread.is_alive():
+            logger.debug("Restarting dead reckoning with new position")
+            self.stop_dead_reckoning.set()
+            self.dead_reckoning_thread.join(timeout=1)
+        speed = data.get('speed', 0)
+        shift_state = data.get('shift_state')
+        if (speed is not None and speed > 0) or shift_state in ['D', 'R']:
+            logger.info(f"Starting dead reckoning interpolation (speed: {speed}mph, gear: {shift_state})")
+            self.stop_dead_reckoning.clear()
+            self.dead_reckoning_thread = threading.Thread(
+                target=self.dead_reckoning_update, args=(data.copy(),))
+            self.dead_reckoning_thread.start()
         else:
-            # Extract initial data to save position
-            initial_data = self.extract_relevant_data(vehicle_data, vehicle)
-            if initial_data.get('latitude') and initial_data.get('longitude'):
-                self.last_known_valid_data = initial_data
-                self.save_last_position_to_file(initial_data)
-                logger.info(f"Saved initial position: {initial_data.get('latitude')}, {initial_data.get('longitude')}")
-        
-        # Main loop
-        consecutive_no_gps_count = 0
-        vehicle_woken_once = True  # We already woke it in initialization
-        
+            logger.debug(f"Vehicle not moving (speed: {speed}mph, gear: {shift_state}), skipping dead reckoning")
+
+    def _handle_valid_gps(self, relevant_data):
+        """Persist + send a fresh fix and (re)start interpolation."""
+        self.consecutive_no_gps_count = 0
+        self.last_known_valid_data = relevant_data.copy()
+        self.save_last_position_to_file(self.last_known_valid_data)
+        self.send_to_cot(relevant_data)
+        if getattr(self.config, 'DEAD_RECKONING_ENABLED', False):
+            self._start_dead_reckoning(relevant_data.copy())
+
+    def _handle_missing_gps(self):
+        """No fresh GPS: keep interpolating / resend the last known position."""
+        logger.warning("No valid GPS coordinates from Tesla API")
+        if not (self.dead_reckoning_thread and self.dead_reckoning_thread.is_alive()):
+            if getattr(self.config, 'DEAD_RECKONING_ENABLED', False):
+                if self.last_known_valid_data and self.last_known_valid_data.get('speed', 0):
+                    logger.info("No GPS - starting dead reckoning based on last known position")
+                    self.stop_dead_reckoning.clear()
+                    self.dead_reckoning_thread = threading.Thread(
+                        target=self.dead_reckoning_update,
+                        args=(self.last_known_valid_data.copy(),))
+                    self.dead_reckoning_thread.start()
+        self.consecutive_no_gps_count += 1
+        logger.warning(f"No valid GPS data available (count: {self.consecutive_no_gps_count})")
+        if self.last_known_valid_data:
+            logger.debug("Using last known position")
+            self.send_to_cot(self.last_known_valid_data)
+
+    def _recheck_wake(self, vehicle):
+        """Wake the vehicle mid-loop if it is asleep (only when not already woken)."""
+        if self.vehicle_woken_once:
+            return
+        vehicle_list = vehicle._owner.vehicle_list()
+        for v in vehicle_list:
+            if v['id'] == vehicle['id']:
+                if v.get('state') == 'asleep':
+                    logger.info(f"Vehicle {vehicle.get('display_name')} is asleep. Waking for initial position...")
+                    try:
+                        vehicle.sync_wake_up()
+                        self.vehicle_woken_once = True
+                        logger.info("Vehicle woken successfully")
+                    except Exception as e:
+                        logger.warning(f"Failed to wake vehicle: {e}")
+                break
+
+    def _poll_once(self, vehicle):
+        """Run one tracking iteration: fetch, process, and sleep one interval."""
+        self._recheck_wake(vehicle)
+        try:
+            vehicle_data = vehicle.get_vehicle_data(endpoints=_LOOP_ENDPOINTS)
+            self.save_debug_capture(vehicle_data, "vehicle_data")
+            if self.consecutive_errors > 0 or self.rate_limit_backoff > 1:
+                logger.info("API responding normally again. Resetting backoff.")
+                self.consecutive_errors = 0
+                self.rate_limit_backoff = 1
+        except Exception as e:
+            time.sleep(self._handle_api_error(e))
+            return
+
+        relevant_data = self.extract_relevant_data(vehicle_data, vehicle)
+        speed = relevant_data.get('speed', 0)
+        speed_display = f"{speed}mph" if speed is not None else "0mph"
+        dr_status = "ENABLED" if getattr(self.config, 'DEAD_RECKONING_ENABLED', False) else "DISABLED"
+        ap_state = relevant_data.get('autopilot_state')
+        if ap_state is None and relevant_data.get('shift_state') in ['D', 'R']:
+            logger.warning("autopilot_state field not available in Tesla API response - FSD detection may not work")
+        logger.info(f"Got vehicle data: lat={relevant_data.get('latitude')}, lon={relevant_data.get('longitude')}, speed={speed_display}, battery={relevant_data.get('battery_level')}%, autopilot_state={ap_state}, UID={relevant_data.get('UID')}, dead_reckoning={dr_status}")
+
+        if relevant_data.get('latitude') and relevant_data.get('longitude'):
+            self._handle_valid_gps(relevant_data)
+        else:
+            self._handle_missing_gps()
+
+        time.sleep(self.config.API_LOOP_DELAY)
+
+    def fetch_and_send_data_for_vehicle(self, vehicle):  # pragma: no cover - infinite supervisor loop
+        """Main loop: fetch from the Tesla API and forward to TAK until the process exits."""
+        self.consecutive_no_gps_count = 0
+        self.vehicle_woken_once = True  # already woken during initial seeding
+        if not self._seed_initial_position(vehicle):
+            return
         while True:
             try:
-                # Check if vehicle needs to be woken (only if we haven't woken it yet)
-                if not vehicle_woken_once:
-                    # Get fresh vehicle state
-                    vehicle_list = vehicle._owner.vehicle_list()
-                    for v in vehicle_list:
-                        if v['id'] == vehicle['id']:
-                            if v.get('state') == 'asleep':
-                                logger.info(f"Vehicle {vehicle.get('display_name')} is asleep. Waking for initial position...")
-                                try:
-                                    vehicle.sync_wake_up()
-                                    vehicle_woken_once = True
-                                    logger.info("Vehicle woken successfully")
-                                except Exception as e:
-                                    logger.warning(f"Failed to wake vehicle: {e}")
-                            break
-                
-                # Try to get vehicle data
-                try:
-                    vehicle_data = vehicle.get_vehicle_data(endpoints='location_data;drive_state;charge_state;vehicle_state;climate_state;vehicle_config')
-                    
-                    # Save debug capture
-                    self.save_debug_capture(vehicle_data, "vehicle_data")
-                    
-                    # Reset rate limiting on success
-                    if self.consecutive_errors > 0 or self.rate_limit_backoff > 1:
-                        logger.info(f"API responding normally again. Resetting backoff.")
-                        self.consecutive_errors = 0
-                        self.rate_limit_backoff = 1
-                        
-                except Exception as e:
-                    error_str = str(e).lower()
-                    
-                    # Check for rate limiting indicators
-                    if any(indicator in error_str for indicator in ['429', 'rate limit', 'too many requests', 'timeout']):
-                        self.consecutive_errors += 1
-                        self.rate_limit_backoff = min(self.rate_limit_backoff * 2, 32)  # Max 32x backoff
-                        self.last_rate_limit_time = time.time()
-                        
-                        delay = self.config.API_LOOP_DELAY * self.rate_limit_backoff
-                        logger.warning(f"Rate limit detected! Backing off to {delay}s delay (error #{self.consecutive_errors})")
-                        logger.warning(f"Error details: {e}")
-                        
-                        # Send cached position to keep TAK updated
-                        if self.last_known_valid_data:
-                            self.send_to_cot(self.last_known_valid_data)
-                            
-                        time.sleep(delay)
-                        continue
-                        
-                    elif "vehicle unavailable" in error_str or "asleep" in error_str:
-                        logger.info(f"Vehicle is asleep/unavailable. Using last known position.")
-                        if self.last_known_valid_data:
-                            self.send_to_cot(self.last_known_valid_data)
-                        else:
-                            logger.warning("No last known position available")
-                        time.sleep(self.config.API_LOOP_DELAY)
-                        continue
-                    else:
-                        # Other errors - log and continue
-                        self.consecutive_errors += 1
-                        logger.error(f"API error (#{self.consecutive_errors}): {e}")
-                        
-                        # If we're getting repeated errors, start backing off
-                        if self.consecutive_errors >= 3:
-                            self.rate_limit_backoff = min(self.rate_limit_backoff * 1.5, 16)
-                            delay = self.config.API_LOOP_DELAY * self.rate_limit_backoff
-                            logger.warning(f"Multiple API errors detected. Backing off to {delay}s delay")
-                            time.sleep(delay)
-                        else:
-                            time.sleep(self.config.API_LOOP_DELAY)
-                        continue
-                
-                relevant_data = self.extract_relevant_data(vehicle_data, vehicle)
-                
-                # Log key data including speed and FSD status for debugging
-                speed = relevant_data.get('speed', 0)
-                speed_display = f"{speed}mph" if speed is not None else "0mph"
-                dr_status = "ENABLED" if getattr(self.config, 'DEAD_RECKONING_ENABLED', False) else "DISABLED"
-                
-                # Check if autopilot_state is available
-                ap_state = relevant_data.get('autopilot_state')
-                if ap_state is None and relevant_data.get('shift_state') in ['D', 'R']:
-                    logger.warning("autopilot_state field not available in Tesla API response - FSD detection may not work")
-                
-                logger.info(f"Got vehicle data: lat={relevant_data.get('latitude')}, lon={relevant_data.get('longitude')}, speed={speed_display}, battery={relevant_data.get('battery_level')}%, autopilot_state={ap_state}, UID={relevant_data.get('UID')}, dead_reckoning={dr_status}")
-                
-                
-                # Check if we have valid GPS data
-                if relevant_data.get('latitude') and relevant_data.get('longitude'):
-                    consecutive_no_gps_count = 0  # Reset counter
-                    
-                    # Save valid position
-                    self.last_known_valid_data = relevant_data.copy()
-                    self.save_last_position_to_file(self.last_known_valid_data)
-                    
-                    # Send current position
-                    self.send_to_cot(relevant_data)
-                    
-                    # Start or restart dead reckoning for interpolation between GPS updates
-                    if getattr(self.config, 'DEAD_RECKONING_ENABLED', False):
-                        # Stop existing dead reckoning thread if running
-                        if self.dead_reckoning_thread and self.dead_reckoning_thread.is_alive():
-                            logger.debug("Restarting dead reckoning with new position")
-                            self.stop_dead_reckoning.set()
-                            self.dead_reckoning_thread.join(timeout=1)
-                        
-                        # Start dead reckoning if vehicle is moving OR if shift state is D/R
-                        speed = relevant_data.get('speed', 0)
-                        shift_state = relevant_data.get('shift_state')
-                        if (speed is not None and speed > 0) or shift_state in ['D', 'R']:
-                            logger.info(f"Starting dead reckoning interpolation (speed: {speed}mph, gear: {shift_state})")
-                            self.stop_dead_reckoning.clear()
-                            self.dead_reckoning_thread = threading.Thread(
-                                target=self.dead_reckoning_update,
-                                args=(relevant_data.copy(),)
-                            )
-                            self.dead_reckoning_thread.start()
-                        else:
-                            logger.debug(f"Vehicle not moving (speed: {speed}mph, gear: {shift_state}), skipping dead reckoning")
-                else:
-                    logger.warning("No valid GPS coordinates from Tesla API")
-                    
-                    # Continue dead reckoning if already running
-                    if not (self.dead_reckoning_thread and self.dead_reckoning_thread.is_alive()):
-                        if getattr(self.config, 'DEAD_RECKONING_ENABLED', False):
-                            if self.last_known_valid_data and self.last_known_valid_data.get('speed', 0):
-                                logger.info("No GPS - starting dead reckoning based on last known position")
-                                self.stop_dead_reckoning.clear()
-                                self.dead_reckoning_thread = threading.Thread(
-                                    target=self.dead_reckoning_update,
-                                    args=(self.last_known_valid_data.copy(),)
-                                )
-                                self.dead_reckoning_thread.start()
-                    
-                    consecutive_no_gps_count += 1
-                    logger.warning(f"No valid GPS data available (count: {consecutive_no_gps_count})")
-                    
-                    # Don't keep waking the vehicle if it's parked
-                    # We already got initial position during setup
-                    # Just use the last known position
-                    
-                    # Use last known position if available
-                    if self.last_known_valid_data:
-                        logger.debug("Using last known position")
-                        # Send last known position to keep it alive in TAK
-                        self.send_to_cot(self.last_known_valid_data)
-                
-                time.sleep(self.config.API_LOOP_DELAY)
-                
+                self._poll_once(vehicle)
             except Exception as e:
                 logger.error(f"Error fetching vehicle data: {e}")
                 time.sleep(self.config.API_LOOP_DELAY)

--- a/teslaontarget/tesla_api.py
+++ b/teslaontarget/tesla_api.py
@@ -237,11 +237,12 @@ class TeslaCoT:
         current_lat = initial_data.get('latitude')
         current_lon = initial_data.get('longitude')
         
-        logger.info(f"Dead reckoning started for up to {max_duration}s from lat={current_lat:.6f}, lon={current_lon:.6f}")
-        
+        logger.info(f"Dead reckoning started for up to {max_duration}s from lat={current_lat}, lon={current_lon}")
+
         update_count = 0
         while not self.stop_dead_reckoning.is_set():
-            if current_lat and current_lon:
+            # 0.0 is a valid coordinate (equator / prime meridian) -- check presence.
+            if current_lat is not None and current_lon is not None:
                 # Wait for the next update interval
                 time.sleep(self.config.DEAD_RECKONING_DELAY)
                 

--- a/teslaontarget/tesla_api.py
+++ b/teslaontarget/tesla_api.py
@@ -55,9 +55,8 @@ class TeslaCoT:
         self.consecutive_errors = 0
         self.last_rate_limit_time = 0
         self.max_wake_attempts = 3
-        # Loop state (promoted from locals so the loop body is testable)
+        # Loop state (promoted from a local so the loop body is testable)
         self.consecutive_no_gps_count = 0
-        self.vehicle_woken_once = True
         
         # Debug mode - captures all Tesla API responses
         self.debug_mode = getattr(self.config, 'DEBUG_MODE', True)  # Default to True for now
@@ -361,7 +360,7 @@ class TeslaCoT:
             logger.error(f"No cached data available for {vehicle.get('display_name', 'Unknown')}")
             return False
         initial_data = self.extract_relevant_data(vehicle_data, vehicle)
-        if initial_data.get('latitude') and initial_data.get('longitude'):
+        if self._has_coordinates(initial_data):
             self.last_known_valid_data = initial_data
             self.save_last_position_to_file(initial_data)
             logger.info(f"Saved initial position: {initial_data.get('latitude')}, {initial_data.get('longitude')}")
@@ -449,26 +448,13 @@ class TeslaCoT:
             logger.debug("Using last known position")
             self.send_to_cot(self.last_known_valid_data)
 
-    def _recheck_wake(self, vehicle):
-        """Wake the vehicle mid-loop if it is asleep (only when not already woken)."""
-        if self.vehicle_woken_once:
-            return
-        vehicle_list = vehicle._owner.vehicle_list()
-        for v in vehicle_list:
-            if v['id'] == vehicle['id']:
-                if v.get('state') == 'asleep':
-                    logger.info(f"Vehicle {vehicle.get('display_name')} is asleep. Waking for initial position...")
-                    try:
-                        vehicle.sync_wake_up()
-                        self.vehicle_woken_once = True
-                        logger.info("Vehicle woken successfully")
-                    except Exception as e:
-                        logger.warning(f"Failed to wake vehicle: {e}")
-                break
+    @staticmethod
+    def _has_coordinates(data):
+        """True when both coordinates are present (0.0 is a valid coordinate)."""
+        return data.get('latitude') is not None and data.get('longitude') is not None
 
     def _poll_once(self, vehicle):
         """Run one tracking iteration: fetch, process, and sleep one interval."""
-        self._recheck_wake(vehicle)
         try:
             vehicle_data = vehicle.get_vehicle_data(endpoints=_LOOP_ENDPOINTS)
             self.save_debug_capture(vehicle_data, "vehicle_data")
@@ -489,7 +475,7 @@ class TeslaCoT:
             logger.warning("autopilot_state field not available in Tesla API response - FSD detection may not work")
         logger.info(f"Got vehicle data: lat={relevant_data.get('latitude')}, lon={relevant_data.get('longitude')}, speed={speed_display}, battery={relevant_data.get('battery_level')}%, autopilot_state={ap_state}, UID={relevant_data.get('UID')}, dead_reckoning={dr_status}")
 
-        if relevant_data.get('latitude') and relevant_data.get('longitude'):
+        if self._has_coordinates(relevant_data):
             self._handle_valid_gps(relevant_data)
         else:
             self._handle_missing_gps()
@@ -499,7 +485,6 @@ class TeslaCoT:
     def fetch_and_send_data_for_vehicle(self, vehicle):  # pragma: no cover - infinite supervisor loop
         """Main loop: fetch from the Tesla API and forward to TAK until the process exits."""
         self.consecutive_no_gps_count = 0
-        self.vehicle_woken_once = True  # already woken during initial seeding
         if not self._seed_initial_position(vehicle):
             return
         while True:

--- a/teslaontarget/tesla_api.py
+++ b/teslaontarget/tesla_api.py
@@ -53,7 +53,6 @@ class TeslaCoT:
         # Rate limiting tracking
         self.rate_limit_backoff = 1  # Multiplier for delays
         self.consecutive_errors = 0
-        self.last_rate_limit_time = 0
         self.max_wake_attempts = 3
         # Loop state (promoted from a local so the loop body is testable)
         self.consecutive_no_gps_count = 0
@@ -381,7 +380,6 @@ class TeslaCoT:
         if kind == "rate_limit":
             self.consecutive_errors += 1
             self.rate_limit_backoff = min(self.rate_limit_backoff * 2, 32)
-            self.last_rate_limit_time = time.time()
             delay = self.config.API_LOOP_DELAY * self.rate_limit_backoff
             logger.warning(f"Rate limit detected! Backing off to {delay}s delay (error #{self.consecutive_errors})")
             logger.warning(f"Error details: {exc}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared test configuration.
+
+Disable Hypothesis's per-example deadline: under coverage/mutation instrumentation
+(pytest-cov, mutmut) the code under test runs slower and would otherwise trip the
+default 200ms deadline, producing flaky failures unrelated to behavior.
+"""
+from hypothesis import HealthCheck, settings
+
+settings.register_profile(
+    "default",
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.load_profile("default")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,65 @@
+"""Tests for teslaontarget.auth.main (interactive Tesla auth, fully mocked)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teslaontarget import auth
+
+
+@pytest.fixture
+def tesla():
+    with patch("teslaontarget.auth.Tesla") as T, patch("teslaontarget.auth.Config"):
+        yield T.return_value
+
+
+def test_already_authorized_tests_connection_and_returns(tesla, capsys):
+    tesla.authorized = True
+    tesla.vehicle_list.return_value = [{"display_name": "Tron", "state": "online"}]
+    auth.main()
+    out = capsys.readouterr().out
+    assert "Already authenticated" in out
+    tesla.fetch_token.assert_not_called()
+
+
+def test_authorized_but_token_invalid_falls_through_to_reauth(tesla):
+    tesla.authorized = True
+    # first vehicle_list (validation) fails, second (after fetch_token) succeeds
+    tesla.vehicle_list.side_effect = [Exception("invalid"),
+                                      [{"display_name": "X", "vin": "123456789"}]]
+    tesla.authorization_url.return_value = "https://auth"
+    with patch("teslaontarget.auth.webbrowser.open"), \
+         patch("builtins.input", return_value="https://redirect?code=abc"):
+        auth.main()
+    tesla.fetch_token.assert_called_once()
+
+
+def test_fresh_auth_opens_browser_and_fetches_token(tesla):
+    tesla.authorized = False
+    tesla.authorization_url.return_value = "https://auth"
+    tesla.vehicle_list.return_value = [{"display_name": "X", "vin": "7SAYGDEF4PF751099"}]
+    with patch("teslaontarget.auth.webbrowser.open") as wb, \
+         patch("builtins.input", return_value="https://r?code=abc"):
+        auth.main()
+    wb.assert_called_once_with("https://auth")
+    tesla.fetch_token.assert_called_once_with(authorization_response="https://r?code=abc")
+
+
+def test_browser_open_failure_prints_manual_url(tesla, capsys):
+    tesla.authorized = False
+    tesla.authorization_url.return_value = "https://auth"
+    tesla.vehicle_list.return_value = []
+    with patch("teslaontarget.auth.webbrowser.open", side_effect=Exception("no display")), \
+         patch("builtins.input", return_value="https://r"):
+        auth.main()
+    assert "manually open" in capsys.readouterr().out
+    tesla.fetch_token.assert_called_once()
+
+
+def test_fetch_token_failure_is_handled(tesla, capsys):
+    tesla.authorized = False
+    tesla.authorization_url.return_value = "https://auth"
+    tesla.fetch_token.side_effect = Exception("bad code")
+    with patch("teslaontarget.auth.webbrowser.open"), \
+         patch("builtins.input", return_value="https://r"):
+        auth.main()  # must not raise
+    assert "Authentication failed" in capsys.readouterr().out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,8 @@ class TestParseAndConfig:
 class TestSelectVehicles:
     def test_no_vehicles_exits(self, monkeypatch):
         monkeypatch.setattr(Config, "VEHICLE_FILTER", [], raising=False)
-        tesla = MagicMock(); tesla.vehicle_list.return_value = []
+        tesla = MagicMock()
+        tesla.vehicle_list.return_value = []
         with pytest.raises(SystemExit):
             cli._select_vehicles(tesla)
 
@@ -121,12 +122,8 @@ class TestBuildHealthMonitor:
 
 class TestWakeVehicles:
     def test_wakes_asleep_only(self):
-        asleep = {"state": "asleep", "display_name": "A"}
-        online = {"state": "online", "display_name": "B"}
-        asleep_v = MagicMock(); asleep_v.get.side_effect = asleep.get
-        asleep_v.__getitem__ = lambda s, k: asleep[k]
-        # simpler: use dict-like mocks
-        a = _vmock("asleep"); b = _vmock("online")
+        a = _vmock("asleep")
+        b = _vmock("online")
         cli._wake_vehicles([a, b])
         a.sync_wake_up.assert_called_once()
         b.sync_wake_up.assert_not_called()
@@ -161,8 +158,10 @@ class TestMonitorThreads:
     def test_runs_one_pass_then_stops(self, monkeypatch):
         monkeypatch.setattr(cli, "running", True)
         monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
-        t_alive = MagicMock(); t_alive.is_alive.return_value = True
-        t_dead = MagicMock(); t_dead.is_alive.return_value = False
+        t_alive = MagicMock()
+        t_alive.is_alive.return_value = True
+        t_dead = MagicMock()
+        t_dead.is_alive.return_value = False
 
         def stop(_):
             cli.running = False
@@ -173,8 +172,10 @@ class TestMonitorThreads:
     def test_all_alive_no_warning(self, monkeypatch):
         monkeypatch.setattr(cli, "running", True)
         monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
-        t1 = MagicMock(); t1.is_alive.return_value = True
-        t2 = MagicMock(); t2.is_alive.return_value = True
+        t1 = MagicMock()
+        t1.is_alive.return_value = True
+        t2 = MagicMock()
+        t2.is_alive.return_value = True
 
         def stop(_):
             cli.running = False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,227 @@
+"""Tests for teslaontarget.cli (entry point, fully mocked)."""
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teslaontarget import cli
+from teslaontarget.config_handler import Config
+
+
+def test_main_module_is_importable():
+    # Covers teslaontarget/__main__.py (the `python -m teslaontarget` shim).
+    # __name__ != "__main__" here, so main() is not invoked, only the import runs.
+    import teslaontarget.__main__ as entry
+    assert entry.main is not None
+
+
+class TestSignalHandler:
+    def test_sets_running_false(self, monkeypatch):
+        monkeypatch.setattr(cli, "running", True)
+        cli.signal_handler(2, None)
+        assert cli.running is False
+
+
+class TestLogHandlers:
+    def test_default_adds_file_handler(self):
+        with patch("teslaontarget.cli.logging.FileHandler") as FH:
+            handlers = cli._make_log_handlers()
+        assert len(handlers) == 2  # stream + file
+        FH.assert_called_once_with("teslaontarget.log")
+
+    def test_uses_logs_dir_when_writable(self):
+        with patch("teslaontarget.cli.os.path.exists", return_value=True), \
+             patch("teslaontarget.cli.os.access", return_value=True), \
+             patch("teslaontarget.cli.logging.FileHandler") as FH:
+            cli._make_log_handlers()
+        FH.assert_called_once_with("/logs/teslaontarget.log")
+
+    def test_file_handler_error_falls_back_to_stdout(self, capsys):
+        with patch("teslaontarget.cli.logging.FileHandler", side_effect=OSError("ro")):
+            handlers = cli._make_log_handlers()
+        assert len(handlers) == 1  # stream only
+        assert "Unable to create log file" in capsys.readouterr().out
+
+
+class TestParseAndConfig:
+    def test_parse_args(self):
+        with patch("sys.argv", ["prog", "--debug", "--config", "/x/config.py"]):
+            args = cli._parse_args()
+        assert args.debug is True and args.config == "/x/config.py"
+
+    def test_load_valid_config(self, monkeypatch):
+        monkeypatch.setattr(Config, "load_from_file", MagicMock())
+        monkeypatch.setattr(Config, "validate", MagicMock(return_value=True))
+        cli._load_and_validate_config(MagicMock(debug=False))
+
+    def test_debug_flag_sets_level(self, monkeypatch):
+        monkeypatch.setattr(Config, "load_from_file", MagicMock())
+        monkeypatch.setattr(Config, "validate", MagicMock(return_value=True))
+        cli._load_and_validate_config(MagicMock(debug=True))
+        assert logging.getLogger().level == logging.DEBUG
+
+    def test_invalid_config_exits(self, monkeypatch):
+        monkeypatch.setattr(Config, "load_from_file", MagicMock())
+        monkeypatch.setattr(Config, "validate", MagicMock(return_value=False))
+        with pytest.raises(SystemExit):
+            cli._load_and_validate_config(MagicMock(debug=False))
+
+
+class TestSelectVehicles:
+    def test_no_vehicles_exits(self, monkeypatch):
+        monkeypatch.setattr(Config, "VEHICLE_FILTER", [], raising=False)
+        tesla = MagicMock(); tesla.vehicle_list.return_value = []
+        with pytest.raises(SystemExit):
+            cli._select_vehicles(tesla)
+
+    def test_no_filter_returns_all(self, monkeypatch):
+        monkeypatch.setattr(Config, "VEHICLE_FILTER", [], raising=False)
+        tesla = MagicMock()
+        tesla.vehicle_list.return_value = [{"display_name": "A"}, {"display_name": "B"}]
+        assert len(cli._select_vehicles(tesla)) == 2
+
+    def test_filter_matches_subset(self, monkeypatch):
+        monkeypatch.setattr(Config, "VEHICLE_FILTER", ["Tron"], raising=False)
+        tesla = MagicMock()
+        tesla.vehicle_list.return_value = [
+            {"display_name": "Tron", "vin": "1"}, {"display_name": "Other", "vin": "2"}]
+        result = cli._select_vehicles(tesla)
+        assert len(result) == 1 and result[0]["display_name"] == "Tron"
+
+    def test_filter_no_match_exits(self, monkeypatch):
+        monkeypatch.setattr(Config, "VEHICLE_FILTER", ["Nope"], raising=False)
+        tesla = MagicMock()
+        tesla.vehicle_list.return_value = [{"display_name": "Tron", "vin": "1"}]
+        with pytest.raises(SystemExit):
+            cli._select_vehicles(tesla)
+
+
+class TestBuildHealthMonitor:
+    def test_uses_defaults_when_unset(self, monkeypatch):
+        for attr in ("HEALTH_NO_SEND_SECONDS", "HEALTH_CHECK_INTERVAL", "HEALTH_HARD_RESTART_SECONDS"):
+            monkeypatch.setattr(Config, attr, 0, raising=False)
+        monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
+        with patch("teslaontarget.cli.HealthMonitor") as HM:
+            cli._build_health_monitor(MagicMock())
+        kw = HM.call_args.kwargs
+        assert kw["max_no_send_seconds"] == 120  # max(120, 10*8)
+        assert kw["check_interval"] == 15
+        assert kw["hard_restart_seconds"] == 600
+
+    def test_uses_configured_values(self, monkeypatch):
+        monkeypatch.setattr(Config, "HEALTH_NO_SEND_SECONDS", 300, raising=False)
+        monkeypatch.setattr(Config, "HEALTH_CHECK_INTERVAL", 30, raising=False)
+        monkeypatch.setattr(Config, "HEALTH_HARD_RESTART_SECONDS", 999, raising=False)
+        monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
+        with patch("teslaontarget.cli.HealthMonitor") as HM:
+            cli._build_health_monitor(MagicMock())
+        kw = HM.call_args.kwargs
+        assert kw["max_no_send_seconds"] == 300 and kw["hard_restart_seconds"] == 999
+
+
+class TestWakeVehicles:
+    def test_wakes_asleep_only(self):
+        asleep = {"state": "asleep", "display_name": "A"}
+        online = {"state": "online", "display_name": "B"}
+        asleep_v = MagicMock(); asleep_v.get.side_effect = asleep.get
+        asleep_v.__getitem__ = lambda s, k: asleep[k]
+        # simpler: use dict-like mocks
+        a = _vmock("asleep"); b = _vmock("online")
+        cli._wake_vehicles([a, b])
+        a.sync_wake_up.assert_called_once()
+        b.sync_wake_up.assert_not_called()
+
+    def test_wake_error_swallowed(self):
+        a = _vmock("asleep")
+        a.sync_wake_up.side_effect = RuntimeError("x")
+        cli._wake_vehicles([a])  # must not raise
+
+
+def _vmock(state):
+    data = {"state": state, "display_name": "Car"}
+    m = MagicMock()
+    m.get.side_effect = data.get
+    m.__getitem__ = lambda s, k: data[k]
+    return m
+
+
+class TestStartTracking:
+    def test_spawns_one_thread_per_vehicle(self, monkeypatch):
+        monkeypatch.setattr(Config, "COT_URL", "tcp://h:1", raising=False)
+        v = _vmock("online")
+        v.get.side_effect = {"vin": "VIN1", "display_name": "Car", "state": "online"}.get
+        with patch("teslaontarget.cli.TeslaCoT"), \
+             patch("teslaontarget.cli.threading.Thread") as T:
+            threads = cli._start_tracking_threads([v], MagicMock())
+        assert len(threads) == 1
+        T.return_value.start.assert_called_once()
+
+
+class TestMonitorThreads:
+    def test_runs_one_pass_then_stops(self, monkeypatch):
+        monkeypatch.setattr(cli, "running", True)
+        monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
+        t_alive = MagicMock(); t_alive.is_alive.return_value = True
+        t_dead = MagicMock(); t_dead.is_alive.return_value = False
+
+        def stop(_):
+            cli.running = False
+        with patch("teslaontarget.cli.time.sleep", side_effect=stop):
+            cli._monitor_threads([t_alive, t_dead])  # alive_count 1 < 2 -> warning
+        assert cli.running is False
+
+    def test_all_alive_no_warning(self, monkeypatch):
+        monkeypatch.setattr(cli, "running", True)
+        monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
+        t1 = MagicMock(); t1.is_alive.return_value = True
+        t2 = MagicMock(); t2.is_alive.return_value = True
+
+        def stop(_):
+            cli.running = False
+        with patch("teslaontarget.cli.time.sleep", side_effect=stop):
+            cli._monitor_threads([t1, t2])  # alive_count 2 == 2 -> no warning branch
+        assert cli.running is False
+
+
+class TestMain:
+    def _patch_all(self):
+        from unittest.mock import DEFAULT
+        return patch.multiple(
+            "teslaontarget.cli",
+            _parse_args=DEFAULT, _load_and_validate_config=DEFAULT, Tesla=DEFAULT,
+            _select_vehicles=DEFAULT, TAKClient=DEFAULT, _build_health_monitor=DEFAULT,
+            _wake_vehicles=DEFAULT, _start_tracking_threads=DEFAULT,
+            _monitor_threads=DEFAULT, signal=DEFAULT,
+        )
+
+    @staticmethod
+    def _prime(m):
+        m["_parse_args"].return_value = MagicMock(debug=False, config=None)
+        m["_select_vehicles"].return_value = [{"display_name": "A"}]
+        m["_start_tracking_threads"].return_value = []
+
+    def test_happy_path_starts_and_stops_health(self):
+        with self._patch_all() as m:
+            self._prime(m)
+            cli.main()
+            m["_build_health_monitor"].return_value.start.assert_called_once()
+            m["_build_health_monitor"].return_value.stop.assert_called_once()
+
+    def test_keyboard_interrupt_is_handled(self):
+        with self._patch_all() as m:
+            self._prime(m)
+            m["_monitor_threads"].side_effect = KeyboardInterrupt()
+            cli.main()  # must not raise
+
+    def test_fatal_error_exits(self):
+        with self._patch_all() as m:
+            self._prime(m)
+            m["_select_vehicles"].side_effect = RuntimeError("boom")
+            with pytest.raises(SystemExit):
+                cli.main()
+
+    def test_finally_swallows_health_stop_error(self):
+        with self._patch_all() as m:
+            self._prime(m)
+            m["_build_health_monitor"].return_value.stop.side_effect = RuntimeError("x")
+            cli.main()  # finally must not raise

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -47,7 +47,7 @@ class TestLoadFromFile:
         assert Config.TESLA_USERNAME == "env@b.com"
 
     def test_env_var_tilde_is_expanded(self, tmp_path, monkeypatch):
-        path = _write_config(tmp_path, 'TESLA_USERNAME = "tilde@b.com"\n')
+        _write_config(tmp_path, 'TESLA_USERNAME = "tilde@b.com"\n')
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("TESLAONTARGET_CONFIG", "~/config.py")
         Config.load_from_file()

--- a/tests/test_config_handler.py
+++ b/tests/test_config_handler.py
@@ -1,0 +1,110 @@
+"""Tests for teslaontarget.config_handler.Config (config loading + validation)."""
+import importlib.util
+
+import pytest
+
+import teslaontarget.config_handler as ch
+from teslaontarget.config_handler import Config
+
+_DEFAULTS = {
+    "COT_URL": Config.COT_URL,
+    "API_LOOP_DELAY": Config.API_LOOP_DELAY,
+    "DEAD_RECKONING_DELAY": Config.DEAD_RECKONING_DELAY,
+    "TESLA_USERNAME": Config.TESLA_USERNAME,
+    "LAST_POSITION_FILE": Config.LAST_POSITION_FILE,
+    "MPH_TO_MS": Config.MPH_TO_MS,
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_config(monkeypatch):
+    monkeypatch.delenv("TESLAONTARGET_CONFIG", raising=False)
+    for k, v in _DEFAULTS.items():
+        setattr(Config, k, v)
+    yield
+    for k, v in _DEFAULTS.items():
+        setattr(Config, k, v)
+
+
+def _write_config(tmp_path, body, name="config.py"):
+    p = tmp_path / name
+    p.write_text(body)
+    return str(p)
+
+
+class TestLoadFromFile:
+    def test_explicit_path_loads_public_attrs(self, tmp_path):
+        path = _write_config(tmp_path, 'TESLA_USERNAME = "a@b.com"\nCOT_URL = "tcp://h:1"\n_PRIVATE = 9\n')
+        Config.load_from_file(path)
+        assert Config.TESLA_USERNAME == "a@b.com"
+        assert Config.COT_URL == "tcp://h:1"
+        assert not hasattr(Config, "_PRIVATE")  # underscore names are skipped
+
+    def test_env_var_path_is_used(self, tmp_path, monkeypatch):
+        path = _write_config(tmp_path, 'TESLA_USERNAME = "env@b.com"\n')
+        monkeypatch.setenv("TESLAONTARGET_CONFIG", path)
+        Config.load_from_file()
+        assert Config.TESLA_USERNAME == "env@b.com"
+
+    def test_env_var_tilde_is_expanded(self, tmp_path, monkeypatch):
+        path = _write_config(tmp_path, 'TESLA_USERNAME = "tilde@b.com"\n')
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("TESLAONTARGET_CONFIG", "~/config.py")
+        Config.load_from_file()
+        assert Config.TESLA_USERNAME == "tilde@b.com"
+
+    def test_env_var_pointing_at_directory_falls_back(self, tmp_path, monkeypatch):
+        # A directory is not a file -> env var ignored -> falls through to the
+        # package-adjacent path (which doesn't exist in tests) -> defaults kept.
+        monkeypatch.setenv("TESLAONTARGET_CONFIG", str(tmp_path))
+        Config.load_from_file()
+        assert Config.TESLA_USERNAME is None
+
+    def test_missing_explicit_path_keeps_defaults(self, tmp_path):
+        Config.load_from_file(str(tmp_path / "absent.py"))
+        assert Config.TESLA_USERNAME is None
+
+    def test_no_path_and_no_env_uses_package_fallback(self):
+        # config_path None and TESLAONTARGET_CONFIG unset (fixture) -> falls
+        # through to the package-adjacent config.py (absent in tests).
+        Config.load_from_file()
+        assert Config.TESLA_USERNAME is None
+
+    def test_syntax_error_in_config_is_caught(self, tmp_path):
+        path = _write_config(tmp_path, "this is not valid python =\n")
+        Config.load_from_file(path)  # must not raise
+        assert Config.TESLA_USERNAME is None
+
+    def test_none_spec_is_guarded(self, tmp_path, monkeypatch):
+        path = _write_config(tmp_path, 'TESLA_USERNAME = "x@y.com"\n')
+        monkeypatch.setattr(importlib.util, "spec_from_file_location", lambda *a, **k: None)
+        Config.load_from_file(path)  # guarded, must not raise
+        assert Config.TESLA_USERNAME is None
+
+    def test_none_loader_is_guarded(self, tmp_path, monkeypatch):
+        path = _write_config(tmp_path, 'TESLA_USERNAME = "x@y.com"\n')
+
+        class _SpecNoLoader:
+            loader = None
+
+        monkeypatch.setattr(importlib.util, "spec_from_file_location",
+                            lambda *a, **k: _SpecNoLoader())
+        Config.load_from_file(path)
+        assert Config.TESLA_USERNAME is None
+
+
+class TestValidate:
+    def test_valid_when_username_and_cot_url_set(self):
+        Config.TESLA_USERNAME = "a@b.com"
+        Config.COT_URL = "tcp://h:1"
+        assert Config.validate() is True
+
+    def test_invalid_without_username(self):
+        Config.TESLA_USERNAME = None
+        Config.COT_URL = "tcp://h:1"
+        assert Config.validate() is False
+
+    def test_invalid_without_cot_url(self):
+        Config.TESLA_USERNAME = "a@b.com"
+        Config.COT_URL = ""
+        assert Config.validate() is False

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -2,7 +2,11 @@
 import xml.etree.ElementTree as ET
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+# Robust under mutmut/coverage instrumentation: no deadline, and allow the
+# class-method test to be driven by different executors across mutation runs.
+_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 from teslaontarget.cot import (
     generate_cot_packet,
@@ -200,6 +204,7 @@ class TestProperties:
         "charging_state": st.sampled_from(["Charging", "Disconnected", "Complete", None]),
     })
 
+    @_PROP
     @given(_data)
     def test_always_emits_parseable_xml(self, data):
         root = ET.fromstring(generate_cot_packet(data))

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -1,0 +1,211 @@
+"""Tests for teslaontarget.cot — CoT XML generation from vehicle data."""
+import xml.etree.ElementTree as ET
+
+import pytest
+from hypothesis import given, strategies as st
+
+from teslaontarget.cot import (
+    generate_cot_packet,
+    format_cot_for_tak,
+    celsius_to_fahrenheit,
+)
+
+
+def _parse(data):
+    root = ET.fromstring(generate_cot_packet(data))
+    return root
+
+
+def _remarks(data):
+    return _parse(data).find("./detail/remarks").text
+
+
+class TestEventSkeleton:
+    def test_defaults_for_empty_data(self):
+        root = _parse({})
+        assert root.tag == "event"
+        assert root.get("uid") == "Tesla-Unknown"
+        assert root.get("type") == "a-f-G-E-V-C"
+        assert root.get("how") == "m-g"
+        pt = root.find("point")
+        assert pt.get("lat") == "0"
+        assert pt.get("lon") == "0"
+        assert pt.get("ce") == "12.5"  # stationary default
+        assert root.find("./detail/contact").get("callsign") == "Tesla"
+        assert root.find("./detail/takv").get("device") == "TESLA Model"
+
+    def test_uid_and_callsign_and_model_used(self):
+        root = _parse({"UID": "TESLA-abc", "display_name": "Tron",
+                       "vehicle_model": "Model Y"})
+        assert root.get("uid") == "TESLA-abc"
+        assert root.find("./detail/contact").get("callsign") == "Tron"
+        assert root.find("./detail/uid").get("Droid") == "Tron"
+        assert root.find("./detail/takv").get("device") == "TESLA Model Y"
+
+    def test_lat_lon_passed_through(self):
+        pt = _parse({"latitude": 30.5, "longitude": -87.1}).find("point")
+        assert pt.get("lat") == "30.5"
+        assert pt.get("lon") == "-87.1"
+
+    def test_stale_is_five_minutes_after_start(self):
+        from datetime import datetime
+        root = _parse({})
+        fmt = "%Y-%m-%dT%H:%M:%S.%fZ"
+        start = datetime.strptime(root.get("start"), fmt)
+        stale = datetime.strptime(root.get("stale"), fmt)
+        assert abs((stale - start).total_seconds() - 300) < 2
+
+
+class TestPointAndTrack:
+    def test_moving_uses_tight_circular_error(self):
+        assert _parse({"speed": 50}).find("point").get("ce") == "5.0"
+
+    def test_slow_uses_loose_circular_error(self):
+        assert _parse({"speed": 1}).find("point").get("ce") == "12.5"
+
+    def test_elevation_none_becomes_zero(self):
+        assert _parse({"elevation": None}).find("point").get("hae") == "0.000"
+
+    def test_elevation_value_formatted(self):
+        assert _parse({"elevation": 12.3456}).find("point").get("hae") == "12.346"
+
+    def test_heading_none_becomes_zero(self):
+        assert _parse({"heading": None}).find("./detail/track").get("course") == "0.00000000"
+
+    def test_speed_none_becomes_zero_ms(self):
+        assert _parse({"speed": None}).find("./detail/track").get("speed") == "0.00000000"
+
+    def test_speed_converted_mph_to_ms(self):
+        course = _parse({"speed": 100}).find("./detail/track").get("speed")
+        assert float(course) == pytest.approx(44.704)
+
+    def test_battery_level_int_cast(self):
+        assert _parse({"battery_level": 87.9}).find("./detail/status").get("battery") == "87"
+
+
+class TestRemarks:
+    def test_gear_default_when_falsy(self):
+        assert "Gear: P" in _remarks({"shift_state": ""})
+
+    def test_gear_value_shown(self):
+        assert "Gear: D" in _remarks({"shift_state": "D"})
+
+    def test_range_shown_when_present(self):
+        assert "Range: 165 mi" in _remarks({"battery_range": 165.4})
+
+    def test_range_absent_when_none(self):
+        assert "Range:" not in _remarks({"battery_range": None})
+
+    def test_charging_with_hours_and_minutes(self):
+        r = _remarks({"charging_state": "Charging", "minutes_to_full_charge": 95,
+                      "charge_limit_soc": 90})
+        assert "Charging" in r and "(1h 35m to 90%)" in r
+
+    def test_charging_with_minutes_only(self):
+        r = _remarks({"charging_state": "Charging", "minutes_to_full_charge": 40})
+        assert "(40m to 80%)" in r  # default charge_limit_soc 80
+
+    def test_charging_time_to_full_hours(self):
+        r = _remarks({"charging_state": "Charging", "minutes_to_full_charge": 0,
+                      "time_to_full_charge": 2.5})
+        assert "(2.5h to 80%)" in r
+
+    def test_charging_time_to_full_sub_hour(self):
+        r = _remarks({"charging_state": "Charging", "minutes_to_full_charge": 0,
+                      "time_to_full_charge": 0.5})
+        assert "(30m to 80%)" in r
+
+    def test_charge_port_open_note(self):
+        r = _remarks({"charging_state": "Charging", "charge_port_door_open": True})
+        assert "Port Open" in r
+
+    @pytest.mark.parametrize("state", ["Disconnected", "Complete", None])
+    def test_no_charging_block_when_not_charging(self, state):
+        assert "to 80%" not in _remarks({"charging_state": state})
+
+    @pytest.mark.parametrize("ap,expected", [(2, "AUTOPILOT ACTIVE"),
+                                             (3, "FSD ACTIVE"),
+                                             (1, "AUTOPILOT AVAILABLE")])
+    def test_autopilot_states_when_driving(self, ap, expected):
+        assert expected in _remarks({"shift_state": "D", "autopilot_state": ap})
+
+    def test_no_autopilot_when_parked(self):
+        assert "AUTOPILOT" not in _remarks({"shift_state": "P", "autopilot_state": 2})
+
+    def test_driving_unknown_autopilot_state_adds_nothing(self):
+        # truthy autopilot_state that is not 1/2/3 -> no AP/FSD text appended
+        r = _remarks({"shift_state": "D", "autopilot_state": 4})
+        assert "AUTOPILOT" not in r and "FSD" not in r
+
+    def test_climate_on(self):
+        assert "Climate: ON" in _remarks({"is_climate_on": True})
+
+    def test_parked_security_block(self):
+        r = _remarks({"shift_state": "P", "sentry_mode": True, "locked": True})
+        assert "Sentry: ON" in r and "Doors: Locked" in r
+
+    def test_parked_unlocked_sentry_off(self):
+        r = _remarks({"shift_state": "P", "sentry_mode": False, "locked": False})
+        assert "Sentry: OFF" in r and "Doors: Unlocked" in r
+
+    def test_locked_none_omits_doors(self):
+        assert "Doors:" not in _remarks({"shift_state": "P", "locked": None})
+
+    def test_windows_frunk_trunk_open_alerts(self):
+        r = _remarks({"shift_state": "P", "fd_window": 1, "rp_window": 1,
+                      "ft": 1, "rt": 1})
+        assert "WINDOWS OPEN: FD,RP" in r
+        assert "FRUNK OPEN" in r and "TRUNK OPEN" in r
+
+    def test_shift_state_none_enters_security_block(self):
+        # shift_state explicitly None -> "Gear: P" and security block both apply.
+        r = _remarks({"shift_state": None, "sentry_mode": True})
+        assert "Gear: P" in r and "Sentry: ON" in r
+
+
+class TestFormatForTak:
+    def test_prepends_xml_declaration_and_returns_bytes(self):
+        out = format_cot_for_tak("<event/>")
+        assert isinstance(out, bytes)
+        assert out.startswith(b"<?xml version='1.0' encoding='UTF-8' standalone='yes'?>")
+        assert out.endswith(b"<event/>")
+
+    def test_roundtrip_with_generated_packet(self):
+        out = format_cot_for_tak(generate_cot_packet({"UID": "X"}))
+        # strip declaration, remainder must parse
+        body = out.split(b"?>", 1)[1]
+        assert ET.fromstring(body).get("uid") == "X"
+
+
+class TestCelsiusToFahrenheit:
+    def test_none(self):
+        assert celsius_to_fahrenheit(None) is None
+
+    @pytest.mark.parametrize("c,f", [(0, 32), (100, 212), (-40, -40)])
+    def test_known(self, c, f):
+        assert celsius_to_fahrenheit(c) == f
+
+
+class TestProperties:
+    _data = st.fixed_dictionaries({
+        "latitude": st.floats(-90, 90, allow_nan=False),
+        "longitude": st.floats(-180, 180, allow_nan=False),
+        "speed": st.floats(0, 200, allow_nan=False),
+        "heading": st.floats(0, 360, allow_nan=False),
+        "battery_level": st.integers(0, 100),
+        "shift_state": st.sampled_from(["P", "D", "R", "N", "", None]),
+        "sentry_mode": st.booleans(),
+        "locked": st.sampled_from([True, False, None]),
+        "battery_range": st.one_of(st.none(), st.floats(0, 400, allow_nan=False)),
+        "charging_state": st.sampled_from(["Charging", "Disconnected", "Complete", None]),
+    })
+
+    @given(_data)
+    def test_always_emits_parseable_xml(self, data):
+        root = ET.fromstring(generate_cot_packet(data))
+        assert root.tag == "event"
+        # lat/lon round-trip into the point element
+        assert root.find("point").get("lat") == str(data["latitude"])
+        assert root.find("point").get("lon") == str(data["longitude"])
+        # remarks always present and non-empty
+        assert root.find("./detail/remarks").text

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -4,15 +4,16 @@ import xml.etree.ElementTree as ET
 import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 
-# Robust under mutmut/coverage instrumentation: no deadline, and allow the
-# class-method test to be driven by different executors across mutation runs.
-_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 from teslaontarget.cot import (
     generate_cot_packet,
     format_cot_for_tak,
     celsius_to_fahrenheit,
 )
+
+# Robust under mutmut/coverage instrumentation: no deadline, and allow the
+# class-method test to be driven by different executors across mutation runs.
+_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 
 def _parse(data):

--- a/tests/test_cot.py
+++ b/tests/test_cot.py
@@ -166,6 +166,15 @@ class TestRemarks:
         r = _remarks({"shift_state": None, "sentry_mode": True})
         assert "Gear: P" in r and "Sentry: ON" in r
 
+    def test_none_window_and_trunk_fields_do_not_crash(self):
+        # Regression: Tesla's vehicle_state can return null for window/trunk
+        # fields; extract_relevant_data passes them straight through, so
+        # `None > 0` would raise TypeError mid-packet and drop the send.
+        r = _remarks({"shift_state": "P", "fd_window": None, "fp_window": None,
+                      "rd_window": None, "rp_window": None, "ft": None, "rt": None})
+        assert "WINDOWS OPEN" not in r
+        assert "FRUNK OPEN" not in r and "TRUNK OPEN" not in r
+
 
 class TestFormatForTak:
     def test_prepends_xml_declaration_and_returns_bytes(self):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,151 @@
+"""Tests for teslaontarget.health.HealthMonitor."""
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teslaontarget.health import HealthMonitor
+
+
+def _client(**snapshot):
+    c = MagicMock()
+    c.health_snapshot.return_value = snapshot
+    return c
+
+
+@pytest.fixture
+def monitor(tmp_path):
+    return HealthMonitor(
+        _client(connected=True, last_send_ok=time.time()),
+        health_file=str(tmp_path / "health.json"),
+        max_no_send_seconds=100,
+        check_interval=1,
+        hard_restart_seconds=500,
+    )
+
+
+class TestInit:
+    def test_hard_restart_defaults_to_five_times(self):
+        m = HealthMonitor(MagicMock(), max_no_send_seconds=120, hard_restart_seconds=None)
+        assert m.hard_restart_seconds == 600
+
+    def test_hard_restart_explicit(self):
+        m = HealthMonitor(MagicMock(), max_no_send_seconds=120, hard_restart_seconds=999)
+        assert m.hard_restart_seconds == 999
+
+
+class TestStaleness:
+    def test_none_when_never_sent(self, monitor):
+        assert monitor._staleness(1000.0, None) is None
+
+    def test_seconds_since_last_ok(self, monitor):
+        assert monitor._staleness(1000.0, 940.0) == 60
+
+    def test_never_negative(self, monitor):
+        # clock skew: last_ok in the future -> clamped to 0
+        assert monitor._staleness(1000.0, 1005.0) == 0
+
+
+class TestWriteSnapshot:
+    def test_writes_atomically(self, tmp_path):
+        path = tmp_path / "h.json"
+        m = HealthMonitor(MagicMock(), health_file=str(path))
+        m._write_snapshot({"a": 1})
+        assert json.loads(path.read_text()) == {"a": 1}
+        assert not (tmp_path / "h.json.tmp").exists()  # tmp renamed away
+
+    def test_write_failure_is_swallowed(self, tmp_path):
+        m = HealthMonitor(MagicMock(), health_file=str(tmp_path / "missing" / "h.json"))
+        m._write_snapshot({"a": 1})  # parent dir missing -> caught, no raise
+
+
+class TestCheckOnce:
+    def test_fresh_send_no_action(self, tmp_path):
+        client = _client(connected=True, last_send_ok=1000.0)
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100, hard_restart_seconds=500)
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=1050.0)  # only 50s stale
+        client.disconnect.assert_not_called()
+        client.start_background_reconnect.assert_not_called()
+        ex.assert_not_called()
+        snap = json.loads((tmp_path / "h.json").read_text())
+        assert snap["stale_seconds"] == 50
+
+    def test_stale_forces_reconnect(self, tmp_path):
+        client = _client(connected=False, last_send_ok=1000.0)
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100, hard_restart_seconds=5000)
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=1200.0)  # 200s stale > 100
+        client.disconnect.assert_called_once()
+        client.start_background_reconnect.assert_called_once()
+        ex.assert_not_called()
+
+    def test_disconnect_error_swallowed_still_reconnects(self, tmp_path):
+        client = _client(connected=False, last_send_ok=1000.0)
+        client.disconnect.side_effect = RuntimeError("boom")
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100, hard_restart_seconds=5000)
+        with patch("teslaontarget.health.os._exit"):
+            m._check_once(now=1200.0)
+        client.start_background_reconnect.assert_called_once()
+
+    def test_critical_staleness_exits(self, tmp_path):
+        client = _client(connected=False, last_send_ok=1000.0)
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100, hard_restart_seconds=500)
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=2000.0)  # 1000s stale > 500
+            ex.assert_called_once_with(12)
+
+    def test_never_sent_no_action(self, tmp_path):
+        client = _client(connected=True, last_send_ok=None)
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100)
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=9999.0)
+        client.disconnect.assert_not_called()
+        ex.assert_not_called()
+
+    def test_client_without_snapshot_method(self, tmp_path):
+        client = MagicMock(spec=[])  # no health_snapshot attribute
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"))
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=1000.0)
+        ex.assert_not_called()
+        snap = json.loads((tmp_path / "h.json").read_text())
+        assert snap["tak"] == {}
+
+    def test_no_hard_restart_when_threshold_none(self, tmp_path):
+        client = _client(connected=False, last_send_ok=1000.0)
+        m = HealthMonitor(client, health_file=str(tmp_path / "h.json"),
+                          max_no_send_seconds=100)
+        m.hard_restart_seconds = None  # disable escalation
+        with patch("teslaontarget.health.os._exit") as ex:
+            m._check_once(now=99999.0)
+        ex.assert_not_called()
+
+
+class TestThreadLifecycle:
+    def test_start_then_stop(self, monitor):
+        with patch("teslaontarget.health.os._exit"):
+            monitor.check_interval = 0.02
+            monitor.start()
+            assert monitor._thread.is_alive()
+            time.sleep(0.05)
+            monitor.stop()
+        assert not monitor._thread.is_alive()
+
+    def test_start_is_idempotent(self, monitor):
+        with patch("teslaontarget.health.os._exit"):
+            monitor.check_interval = 0.02
+            monitor.start()
+            first = monitor._thread
+            monitor.start()  # already running -> same thread
+            assert monitor._thread is first
+            monitor.stop()
+
+    def test_stop_without_start_is_safe(self, monitor):
+        monitor.stop()  # no thread -> no raise

--- a/tests/test_tak_client.py
+++ b/tests/test_tak_client.py
@@ -1,0 +1,205 @@
+"""Tests for teslaontarget.tak_client.TAKClient (socket boundary, mocked)."""
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teslaontarget.tak_client import TAKClient
+
+
+@pytest.fixture
+def client():
+    return TAKClient("tcp://10.0.0.5:8087")
+
+
+class TestInit:
+    def test_parses_host_and_port(self, client):
+        assert client.host == "10.0.0.5"
+        assert client.port == 8087
+
+    def test_initial_state(self, client):
+        assert client.socket is None
+        assert client.connected is False
+        assert client.last_send_ok is None
+        assert client.last_error is None
+
+
+class TestConnect:
+    def test_connect_success(self, client):
+        with patch("teslaontarget.tak_client.socket.socket") as sock_cls:
+            sock = sock_cls.return_value
+            assert client.connect() is True
+            assert client.connected is True
+            assert client.last_connect_ok is not None
+            sock.settimeout.assert_called_once_with(10)
+            sock.connect.assert_called_once_with(("10.0.0.5", 8087))
+            sock.setsockopt.assert_called_once()
+
+    def test_connect_disconnects_existing_socket_first(self, client):
+        client.socket = MagicMock()
+        with patch("teslaontarget.tak_client.socket.socket"):
+            with patch.object(client, "disconnect", wraps=client.disconnect) as disc:
+                client.connect()
+                disc.assert_called_once()
+
+    def test_connect_failure_returns_false(self, client):
+        with patch("teslaontarget.tak_client.socket.socket") as sock_cls:
+            sock_cls.return_value.connect.side_effect = socket.error("refused")
+            assert client.connect() is False
+            assert client.connected is False
+
+
+class TestDisconnect:
+    def test_closes_socket(self, client):
+        sock = MagicMock()
+        client.socket = sock
+        client.connected = True
+        client.disconnect()
+        sock.close.assert_called_once()
+        assert client.socket is None
+        assert client.connected is False
+
+    def test_close_error_is_swallowed(self, client):
+        sock = MagicMock()
+        sock.close.side_effect = OSError("bad")
+        client.socket = sock
+        client.disconnect()  # must not raise
+        assert client.socket is None
+
+    def test_joins_live_reconnect_thread(self, client):
+        thread = MagicMock()
+        thread.is_alive.return_value = True
+        client.reconnect_thread = thread
+        client.disconnect()
+        thread.join.assert_called_once_with(timeout=2)
+
+
+class TestSendCot:
+    def test_send_when_connected(self, client):
+        client.connected = True
+        client.socket = MagicMock()
+        assert client.send_cot(b"<event/>") is True
+        client.socket.sendall.assert_called_once_with(b"<event/>")
+        assert client.last_send_ok is not None
+        assert client.last_send_attempt is not None
+
+    def test_connects_first_when_disconnected(self, client):
+        client.connected = False
+        with patch.object(client, "connect", side_effect=lambda: setattr(client, "connected", True) or True) as conn:
+            client.socket = MagicMock()
+            assert client.send_cot(b"x") is True
+            conn.assert_called_once()
+
+    @patch("teslaontarget.tak_client.time.sleep")
+    def test_retries_connect_until_success(self, sleep, client):
+        client.connected = False
+        calls = {"n": 0}
+
+        def fake_connect():
+            calls["n"] += 1
+            if calls["n"] >= 2:
+                client.connected = True
+                client.socket = MagicMock()
+                return True
+            return False
+
+        with patch.object(client, "connect", side_effect=fake_connect):
+            assert client.send_cot(b"x") is True
+        sleep.assert_called_with(30)  # waited after the first failed connect
+
+    @patch("teslaontarget.tak_client.time.sleep")
+    def test_send_error_then_reconnect_and_succeed(self, sleep, client):
+        client.connected = True
+        sock = MagicMock()
+        sock.sendall.side_effect = [socket.error("broken pipe"), None]
+        client.socket = sock
+
+        def reconnect():
+            client.connected = True
+            return True
+
+        with patch.object(client, "connect", side_effect=reconnect):
+            assert client.send_cot(b"x") is True
+        assert client.last_error == "broken pipe"
+        assert client.last_error_time is not None
+
+
+class TestEnsureConnected:
+    def test_connects_when_not_connected(self, client):
+        with patch.object(client, "connect", return_value=True) as conn:
+            assert client.ensure_connected() is True
+            conn.assert_called_once()
+
+    def test_healthy_peek_returns_true(self, client):
+        client.connected = True
+        client.socket = MagicMock()
+        client.socket.recv.return_value = b"x"
+        assert client.ensure_connected() is True
+        client.socket.setblocking.assert_any_call(0)
+        client.socket.setblocking.assert_any_call(1)
+
+    def test_closed_connection_reconnects(self, client):
+        client.connected = True
+        client.socket = MagicMock()
+        client.socket.recv.return_value = b""  # peer closed
+        with patch.object(client, "connect", return_value=True) as conn:
+            assert client.ensure_connected() is True
+            conn.assert_called_once()
+
+    def test_socket_error_on_peek_is_ignored(self, client):
+        client.connected = True
+        client.socket = MagicMock()
+        client.socket.recv.side_effect = socket.error("EAGAIN")
+        assert client.ensure_connected() is True
+
+
+class TestBackgroundReconnect:
+    def test_start_spawns_thread_when_disconnected(self, client):
+        client.connected = False
+        client.reconnect_thread = None
+        with patch("teslaontarget.tak_client.threading.Thread") as Thread:
+            client.start_background_reconnect()
+            Thread.assert_called_once()
+            Thread.return_value.start.assert_called_once()
+
+    def test_start_noop_when_connected(self, client):
+        client.connected = True
+        with patch("teslaontarget.tak_client.threading.Thread") as Thread:
+            client.start_background_reconnect()
+            Thread.assert_not_called()
+
+    def test_background_reconnect_succeeds_and_exits(self, client):
+        client.connected = False
+        client.stop_reconnect = MagicMock()
+        client.stop_reconnect.is_set.return_value = False
+        with patch.object(client, "connect", return_value=True):
+            client._background_reconnect()  # connects on first try, returns
+
+    def test_background_reconnect_waits_then_stops(self, client):
+        client.connected = False
+        client.stop_reconnect = MagicMock()
+        client.stop_reconnect.is_set.side_effect = [False, True]
+        with patch.object(client, "connect", return_value=False):
+            client._background_reconnect()
+            client.stop_reconnect.wait.assert_called_once_with(client.reconnect_interval)
+
+    def test_background_reconnect_skips_connect_when_already_connected(self, client):
+        # Loop body runs once with connected=True -> skips connect, just waits.
+        client.connected = True
+        client.stop_reconnect = MagicMock()
+        client.stop_reconnect.is_set.side_effect = [False, True]
+        with patch.object(client, "connect") as conn:
+            client._background_reconnect()
+            conn.assert_not_called()
+            client.stop_reconnect.wait.assert_called_once_with(client.reconnect_interval)
+
+
+class TestHealthSnapshot:
+    def test_snapshot_fields(self, client):
+        client.connected = True
+        client.last_send_ok = 123.0
+        snap = client.health_snapshot()
+        assert snap["host"] == "10.0.0.5"
+        assert snap["port"] == 8087
+        assert snap["connected"] is True
+        assert snap["last_send_ok"] == 123.0

--- a/tests/test_tesla_api.py
+++ b/tests/test_tesla_api.py
@@ -1,0 +1,183 @@
+"""Tests for teslaontarget.tesla_api.TeslaCoT (non-loop methods)."""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from teslaontarget.config_handler import Config
+from teslaontarget.tesla_api import TeslaCoT
+
+
+@pytest.fixture
+def cot(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # isolate all file writes to a temp cwd
+    monkeypatch.setattr(Config, "COT_URL", "tcp://h:1", raising=False)
+    monkeypatch.setattr(Config, "DEBUG_MODE", False, raising=False)
+    monkeypatch.setattr(Config, "LAST_POSITION_FILE", "last.json", raising=False)
+    monkeypatch.setattr(Config, "API_LOOP_DELAY", 10, raising=False)
+    monkeypatch.setattr(Config, "DEAD_RECKONING_DELAY", 1, raising=False)
+    monkeypatch.setattr(Config, "MPH_TO_MS", 0.44704, raising=False)
+    return TeslaCoT(vehicle_id="VIN123", tak_client=MagicMock())
+
+
+class TestInit:
+    def test_uses_supplied_tak_client(self, cot):
+        assert cot.vehicle_id == "VIN123"
+        assert cot.positions_queue.maxlen == 2
+        assert cot.debug_mode is False
+
+    def test_creates_tak_client_when_none(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Config, "COT_URL", "tcp://1.2.3.4:9", raising=False)
+        monkeypatch.setattr(Config, "DEBUG_MODE", False, raising=False)
+        with patch("teslaontarget.tesla_api.TAKClient") as TC:
+            TeslaCoT(vehicle_id="v")
+            TC.assert_called_once_with("tcp://1.2.3.4:9")
+
+    def test_debug_mode_makes_capture_dir(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Config, "DEBUG_MODE", True, raising=False)
+        TeslaCoT(vehicle_id="v", tak_client=MagicMock())
+        assert (tmp_path / "tesla_api_captures").is_dir()
+
+    def test_debug_mode_without_vehicle_id(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Config, "DEBUG_MODE", True, raising=False)
+        monkeypatch.setattr(Config, "LAST_POSITION_FILE", "last.json", raising=False)
+        TeslaCoT(vehicle_id=None, tak_client=MagicMock())  # debug on, no id -> no log
+        assert (tmp_path / "tesla_api_captures").is_dir()
+
+
+class TestPositionFilename:
+    def test_sanitizes_vehicle_id(self, cot):
+        cot.vehicle_id = "5YJ/3*E1!a"
+        assert cot._get_position_filename() == "last_position_5YJ3E1a.json"
+
+    def test_falls_back_to_config_when_no_id(self, cot):
+        cot.vehicle_id = None
+        assert cot._get_position_filename() == "last.json"
+
+
+class TestPositionIO:
+    def test_save_then_read_roundtrip(self, cot):
+        cot.save_last_position_to_file({"latitude": 1.0})
+        assert cot.read_last_position_from_file() == {"latitude": 1.0}
+
+    def test_read_missing_returns_none(self, cot):
+        cot.position_file = "does_not_exist.json"
+        assert cot.read_last_position_from_file() is None
+
+    def test_save_error_is_logged_not_raised(self, cot):
+        with patch("teslaontarget.tesla_api.save_json_file", side_effect=OSError("x")):
+            cot.save_last_position_to_file({"a": 1})  # must not raise
+
+
+class TestDebugCapture:
+    def test_noop_when_debug_disabled(self, cot, tmp_path):
+        cot.debug_mode = False
+        cot.save_debug_capture({"a": 1})
+        assert not (tmp_path / "tesla_api_captures").exists()
+
+    def test_writes_capture_when_enabled(self, cot, tmp_path):
+        import os
+        cot.debug_mode = True
+        cot.debug_dir = str(tmp_path / "caps")
+        os.makedirs(cot.debug_dir, exist_ok=True)
+        cot.save_debug_capture({"vin": "X"}, prefix="probe")
+        files = list((tmp_path / "caps").glob("probe_*.json"))
+        assert len(files) == 1
+        body = json.loads(files[0].read_text())
+        assert body["raw_api_response"] == {"vin": "X"}
+        assert cot.capture_count == 1
+
+    def test_write_error_is_swallowed(self, cot):
+        cot.debug_mode = True
+        cot.debug_dir = "/nonexistent_root_dir_xyz"
+        cot.save_debug_capture({"a": 1})  # must not raise
+
+
+class TestSendToCot:
+    def test_success_path(self, cot):
+        cot.tak_client.send_cot.return_value = True
+        cot.send_to_cot({"display_name": "Tron", "latitude": 1, "longitude": 2})
+        cot.tak_client.send_cot.assert_called_once()
+
+    def test_failed_send_warns_no_raise(self, cot):
+        cot.tak_client.send_cot.return_value = False
+        cot.send_to_cot({"latitude": 1, "longitude": 2})
+
+    def test_generation_error_is_caught(self, cot):
+        with patch("teslaontarget.tesla_api.generate_cot_packet", side_effect=ValueError("boom")):
+            cot.send_to_cot({"latitude": 1})  # must not raise
+
+
+def _vehicle(**over):
+    base = {"id_s": "3744443410507808", "display_name": "Tron"}
+    base.update(over)
+    return base
+
+
+class TestExtractRelevantData:
+    def test_uid_is_stable_md5(self, cot):
+        import hashlib
+        d = cot.extract_relevant_data({}, _vehicle())
+        assert d["UID"] == "TESLA-" + hashlib.md5(b"3744443410507808").hexdigest()[:8]
+
+    def test_core_fields_mapped(self, cot):
+        vd = dict(
+            drive_state={"latitude": 30.5, "longitude": -87.1, "speed": 12,
+                         "heading": 90, "shift_state": "D"},
+            charge_state={"battery_level": 64, "charging_state": "Charging",
+                          "battery_range": 200},
+            vehicle_state={"locked": True, "sentry_mode": True, "vehicle_name": "Tron"},
+            climate_state={"is_climate_on": True, "inside_temp": 21},
+        )
+        d = cot.extract_relevant_data(vd, _vehicle())
+        assert d["latitude"] == 30.5 and d["longitude"] == -87.1
+        assert d["speed"] == 12 and d["shift_state"] == "D"
+        assert d["battery_level"] == 64 and d["charging_state"] == "Charging"
+        assert d["locked"] is True and d["sentry_mode"] is True
+        assert d["is_climate_on"] is True
+
+    def test_defaults_when_sections_empty(self, cot):
+        d = cot.extract_relevant_data({}, _vehicle())
+        assert d["latitude"] is None and d["longitude"] is None
+        assert d["speed"] == 0 and d["charging_state"] == "Disconnected"
+        assert d["display_name"] == "Tron"
+        assert d["vehicle_model"] == ""  # no car_type
+
+    @pytest.mark.parametrize("car_type,expected", [
+        ("models", "Model S"), ("modelx", "Model X"), ("model3", "Model 3"),
+        ("modely", "Model Y"), ("cybertruck", "Cybertruck"),
+        ("roadster", "roadster"),  # unmapped -> passthrough
+    ])
+    def test_model_name_mapping(self, cot, car_type, expected):
+        d = cot.extract_relevant_data({"vehicle_config": {"car_type": car_type}}, _vehicle())
+        assert d["vehicle_model"] == expected
+
+    def test_trim_performance_variant(self, cot):
+        d = cot.extract_relevant_data(
+            {"vehicle_config": {"car_type": "modely", "trim_badging": "p74d"}}, _vehicle())
+        assert d["vehicle_model"] == "Model Y Performance"
+
+    def test_trim_long_range_variant(self, cot):
+        d = cot.extract_relevant_data(
+            {"vehicle_config": {"car_type": "model3", "trim_badging": "ld"}}, _vehicle())
+        assert d["vehicle_model"] == "Model 3 Long Range"
+
+    def test_trim_other_uppercased(self, cot):
+        d = cot.extract_relevant_data(
+            {"vehicle_config": {"car_type": "models", "trim_badging": "xx"}}, _vehicle())
+        assert d["vehicle_model"] == "Model S XX"
+
+    def test_year_prefixed(self, cot):
+        d = cot.extract_relevant_data(
+            {"vehicle_config": {"car_type": "modely", "trim_badging": "p", "year": 2024}},
+            _vehicle())
+        assert d["vehicle_model"] == "2024 Model Y Performance"
+
+    def test_vehicle_id_fallback_key(self, cot):
+        import hashlib
+        v = {"vehicle_id": "987", "display_name": "X"}  # no id_s
+        d = cot.extract_relevant_data({}, v)
+        assert d["UID"] == "TESLA-" + hashlib.md5(b"987").hexdigest()[:8]

--- a/tests/test_tesla_api.py
+++ b/tests/test_tesla_api.py
@@ -228,10 +228,15 @@ class TestDeadReckoning:
         self._drive(cot, data, times=[1000, 1001, 1002], max_iters=2)
         cot.send_to_cot.assert_called_once()
 
-    def test_zero_coordinate_breaks_immediately(self, cot):
-        # latitude 0 formats fine for the log but is falsy -> "no valid position"
-        data = {"latitude": 0, "longitude": -87.0, "speed": 0}
-        # max_iters=2 so the loop body runs once and hits the else/break
+    def test_zero_coordinate_is_valid(self, cot):
+        # Regression: latitude 0.0 (equator) is a valid coordinate, not "missing".
+        data = {"latitude": 0.0, "longitude": 0.0, "speed": 0}
+        self._drive(cot, data, times=[1000, 1001, 1100], max_iters=2)
+        cot.send_to_cot.assert_called_once()
+
+    def test_none_coordinate_breaks(self, cot):
+        # Only genuinely-missing coordinates (None) stop dead reckoning.
+        data = {"latitude": None, "longitude": None, "speed": 0}
         self._drive(cot, data, times=[1000, 1001], max_iters=2)
         cot.send_to_cot.assert_not_called()
 

--- a/tests/test_tesla_api.py
+++ b/tests/test_tesla_api.py
@@ -409,19 +409,17 @@ class TestPollOnce:
             cot._poll_once(v)
         assert cot.consecutive_errors == 0 and cot.rate_limit_backoff == 1
 
-    def test_recheck_wake_noop_when_already_woken(self, cot):
+    def test_zero_coordinates_count_as_valid_gps(self, cot):
+        # Regression: lat=0.0 (equator) / lon=0.0 (prime meridian) are valid;
+        # a truthiness check would wrongly treat them as "no GPS".
         v = _fake_vehicle()
-        cot.vehicle_woken_once = True
-        cot._recheck_wake(v)
-        v._owner.vehicle_list.assert_not_called()
-
-    def test_recheck_wake_wakes_asleep_vehicle(self, cot):
-        v = _fake_vehicle()
-        cot.vehicle_woken_once = False
-        v._owner.vehicle_list.return_value = [{"id": 1, "state": "asleep"}]
-        cot._recheck_wake(v)
-        v.sync_wake_up.assert_called_once()
-        assert cot.vehicle_woken_once is True
+        v.get_vehicle_data.return_value = {"drive_state": {"latitude": 0.0, "longitude": 0.0}}
+        cot._handle_valid_gps = MagicMock()
+        cot._handle_missing_gps = MagicMock()
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._poll_once(v)
+        cot._handle_valid_gps.assert_called_once()
+        cot._handle_missing_gps.assert_not_called()
 
 
 class TestHandleGps:
@@ -461,7 +459,8 @@ class TestHandleGps:
 
     def test_missing_gps_thread_alive_skips_start(self, cot, monkeypatch):
         monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", True, raising=False)
-        alive = MagicMock(); alive.is_alive.return_value = True
+        alive = MagicMock()
+        alive.is_alive.return_value = True
         cot.dead_reckoning_thread = alive
         cot.send_to_cot = MagicMock()
         cot.last_known_valid_data = {"latitude": 1}
@@ -493,29 +492,7 @@ class TestHandleGps:
             assert cot._seed_initial_position(v) is True  # no save, still proceeds
 
 
-class TestRecheckWakeEdges:
-    def test_vehicle_not_in_list(self, cot):
-        v = _fake_vehicle()
-        cot.vehicle_woken_once = False
-        v._owner.vehicle_list.return_value = [{"id": 99, "state": "asleep"}]
-        cot._recheck_wake(v)
-        v.sync_wake_up.assert_not_called()  # id mismatch -> never matched
-
-    def test_vehicle_online_not_woken(self, cot):
-        v = _fake_vehicle()
-        cot.vehicle_woken_once = False
-        v._owner.vehicle_list.return_value = [{"id": 1, "state": "online"}]
-        cot._recheck_wake(v)
-        v.sync_wake_up.assert_not_called()
-
-    def test_wake_exception_swallowed(self, cot):
-        v = _fake_vehicle()
-        cot.vehicle_woken_once = False
-        v._owner.vehicle_list.return_value = [{"id": 1, "state": "asleep"}]
-        v.sync_wake_up.side_effect = RuntimeError("x")
-        cot._recheck_wake(v)  # must not raise
-        assert cot.vehicle_woken_once is False  # wake failed
-
+class TestPollOnceExtra:
     def test_poll_warns_on_missing_autopilot_while_driving(self, cot):
         v = _fake_vehicle()
         v.get_vehicle_data.return_value = {

--- a/tests/test_tesla_api.py
+++ b/tests/test_tesla_api.py
@@ -234,3 +234,294 @@ class TestDeadReckoning:
         # max_iters=2 so the loop body runs once and hits the else/break
         self._drive(cot, data, times=[1000, 1001], max_iters=2)
         cot.send_to_cot.assert_not_called()
+
+
+def _fake_vehicle(state="online", **extra):
+    v = type("FakeVehicle", (dict,), {})(
+        {"id_s": "3744443410507808", "id": 1, "display_name": "Tron", "state": state})
+    v.get_vehicle_data = MagicMock()
+    v.sync_wake_up = MagicMock()
+    v._owner = MagicMock()
+    for k, val in extra.items():
+        setattr(v, k, val)
+    return v
+
+
+class TestClassifyApiError:
+    @pytest.mark.parametrize("text,kind", [
+        ("http 429 too many requests", "rate_limit"),
+        ("read timeout occurred", "rate_limit"),
+        ("vehicle unavailable", "unavailable"),
+        ("vehicle is asleep", "unavailable"),
+        ("something exploded", "other"),
+    ])
+    def test_classification(self, cot, text, kind):
+        assert cot._classify_api_error(text) == kind
+
+
+class TestHandleApiError:
+    def test_rate_limit_backs_off_and_sends_cache(self, cot):
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1}
+        delay = cot._handle_api_error(Exception("429 rate limit"))
+        assert cot.rate_limit_backoff == 2
+        assert delay == cot.config.API_LOOP_DELAY * 2
+        cot.send_to_cot.assert_called_once()
+
+    def test_unavailable_uses_cache(self, cot):
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1}
+        delay = cot._handle_api_error(Exception("vehicle unavailable"))
+        assert delay == cot.config.API_LOOP_DELAY
+        cot.send_to_cot.assert_called_once()
+
+    def test_unavailable_without_cache_warns(self, cot):
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = None
+        cot._handle_api_error(Exception("asleep"))
+        cot.send_to_cot.assert_not_called()
+
+    def test_other_error_single(self, cot):
+        delay = cot._handle_api_error(Exception("weird"))
+        assert delay == cot.config.API_LOOP_DELAY
+        assert cot.consecutive_errors == 1
+
+    def test_other_error_escalates_after_three(self, cot):
+        cot.consecutive_errors = 2
+        delay = cot._handle_api_error(Exception("weird"))
+        assert cot.consecutive_errors == 3
+        assert delay > cot.config.API_LOOP_DELAY
+
+
+class TestSeedAndWake:
+    def test_wake_if_asleep_sends_wake(self, cot):
+        v = _fake_vehicle(state="asleep")
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._wake_if_asleep(v)
+        v.sync_wake_up.assert_called_once()
+
+    def test_wake_skipped_when_online(self, cot):
+        v = _fake_vehicle(state="online")
+        cot._wake_if_asleep(v)
+        v.sync_wake_up.assert_not_called()
+
+    def test_wake_error_swallowed(self, cot):
+        v = _fake_vehicle(state="asleep")
+        v.sync_wake_up.side_effect = RuntimeError("nope")
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._wake_if_asleep(v)  # must not raise
+
+    def test_fetch_initial_success(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.return_value = {"vin": "X"}
+        assert cot._fetch_initial_data(v) == {"vin": "X"}
+
+    def test_fetch_initial_all_fail(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.side_effect = Exception("fail")
+        cot.max_wake_attempts = 2
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            assert cot._fetch_initial_data(v) is None
+        assert v.get_vehicle_data.call_count == 2
+
+    def test_seed_no_data_no_cache_returns_false(self, cot):
+        v = _fake_vehicle()
+        cot.last_known_valid_data = None
+        with patch.object(cot, "_fetch_initial_data", return_value=None):
+            assert cot._seed_initial_position(v) is False
+
+    def test_seed_no_data_with_cache_sends_and_proceeds(self, cot):
+        v = _fake_vehicle()
+        cot.last_known_valid_data = {"latitude": 1}
+        cot.send_to_cot = MagicMock()
+        with patch.object(cot, "_fetch_initial_data", return_value=None):
+            assert cot._seed_initial_position(v) is True
+        cot.send_to_cot.assert_called_once()
+
+    def test_seed_with_gps_saves_position(self, cot):
+        v = _fake_vehicle()
+        vd = {"drive_state": {"latitude": 30.0, "longitude": -87.0}}
+        with patch.object(cot, "_fetch_initial_data", return_value=vd):
+            assert cot._seed_initial_position(v) is True
+        assert cot.last_known_valid_data["latitude"] == 30.0
+
+
+class TestDeadReckoningManagement:
+    def test_start_when_moving(self, cot):
+        cot.dead_reckoning_thread = None
+        with patch("teslaontarget.tesla_api.threading.Thread") as T:
+            cot._start_dead_reckoning({"speed": 30, "shift_state": "D"})
+            T.assert_called_once()
+            T.return_value.start.assert_called_once()
+
+    def test_skip_when_parked(self, cot):
+        cot.dead_reckoning_thread = None
+        with patch("teslaontarget.tesla_api.threading.Thread") as T:
+            cot._start_dead_reckoning({"speed": 0, "shift_state": "P"})
+            T.assert_not_called()
+
+    def test_restarts_existing_thread(self, cot):
+        old = MagicMock()
+        old.is_alive.return_value = True
+        cot.dead_reckoning_thread = old
+        with patch("teslaontarget.tesla_api.threading.Thread"):
+            cot._start_dead_reckoning({"speed": 10, "shift_state": "D"})
+        old.join.assert_called_once()
+
+
+class TestPollOnce:
+    def _vd_with_gps(self):
+        return {"drive_state": {"latitude": 30.0, "longitude": -87.0, "speed": 5}}
+
+    def test_valid_gps_path(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.return_value = self._vd_with_gps()
+        cot._handle_valid_gps = MagicMock()
+        cot._handle_missing_gps = MagicMock()
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._poll_once(v)
+        cot._handle_valid_gps.assert_called_once()
+        cot._handle_missing_gps.assert_not_called()
+
+    def test_missing_gps_path(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.return_value = {"drive_state": {}}
+        cot._handle_valid_gps = MagicMock()
+        cot._handle_missing_gps = MagicMock()
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._poll_once(v)
+        cot._handle_missing_gps.assert_called_once()
+
+    def test_error_path_delegates_to_handler(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.side_effect = Exception("429 rate limit")
+        with patch("teslaontarget.tesla_api.time.sleep") as slp:
+            cot._poll_once(v)
+        slp.assert_called_once()  # slept for the handler's backoff delay
+
+    def test_backoff_reset_on_success(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.return_value = self._vd_with_gps()
+        cot.consecutive_errors = 5
+        cot.rate_limit_backoff = 8
+        cot._handle_valid_gps = MagicMock()
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._poll_once(v)
+        assert cot.consecutive_errors == 0 and cot.rate_limit_backoff == 1
+
+    def test_recheck_wake_noop_when_already_woken(self, cot):
+        v = _fake_vehicle()
+        cot.vehicle_woken_once = True
+        cot._recheck_wake(v)
+        v._owner.vehicle_list.assert_not_called()
+
+    def test_recheck_wake_wakes_asleep_vehicle(self, cot):
+        v = _fake_vehicle()
+        cot.vehicle_woken_once = False
+        v._owner.vehicle_list.return_value = [{"id": 1, "state": "asleep"}]
+        cot._recheck_wake(v)
+        v.sync_wake_up.assert_called_once()
+        assert cot.vehicle_woken_once is True
+
+
+class TestHandleGps:
+    def test_valid_gps_saves_sends_and_dr(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", True, raising=False)
+        cot.send_to_cot = MagicMock()
+        cot._start_dead_reckoning = MagicMock()
+        cot._handle_valid_gps({"latitude": 1, "longitude": 2, "speed": 9})
+        assert cot.consecutive_no_gps_count == 0
+        cot.send_to_cot.assert_called_once()
+        cot._start_dead_reckoning.assert_called_once()
+
+    def test_missing_gps_resends_cache(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", False, raising=False)
+        cot.dead_reckoning_thread = None
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1}
+        cot._handle_missing_gps()
+        assert cot.consecutive_no_gps_count == 1
+        cot.send_to_cot.assert_called_once()
+
+    def test_missing_gps_starts_dr_from_cache(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", True, raising=False)
+        cot.dead_reckoning_thread = None
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1, "speed": 20}
+        with patch("teslaontarget.tesla_api.threading.Thread") as T:
+            cot._handle_missing_gps()
+            T.return_value.start.assert_called_once()
+
+    def test_valid_gps_with_dr_disabled(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", False, raising=False)
+        cot.send_to_cot = MagicMock()
+        cot._start_dead_reckoning = MagicMock()
+        cot._handle_valid_gps({"latitude": 1, "longitude": 2})
+        cot._start_dead_reckoning.assert_not_called()
+
+    def test_missing_gps_thread_alive_skips_start(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", True, raising=False)
+        alive = MagicMock(); alive.is_alive.return_value = True
+        cot.dead_reckoning_thread = alive
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1}
+        with patch("teslaontarget.tesla_api.threading.Thread") as T:
+            cot._handle_missing_gps()
+            T.assert_not_called()  # existing thread alive -> no new one
+        cot.send_to_cot.assert_called_once()
+
+    def test_missing_gps_dr_enabled_but_no_speed(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", True, raising=False)
+        cot.dead_reckoning_thread = None
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = {"latitude": 1, "speed": 0}  # not moving
+        with patch("teslaontarget.tesla_api.threading.Thread") as T:
+            cot._handle_missing_gps()
+            T.assert_not_called()
+
+    def test_missing_gps_no_cache_no_send(self, cot, monkeypatch):
+        monkeypatch.setattr(Config, "DEAD_RECKONING_ENABLED", False, raising=False)
+        cot.dead_reckoning_thread = None
+        cot.send_to_cot = MagicMock()
+        cot.last_known_valid_data = None
+        cot._handle_missing_gps()
+        cot.send_to_cot.assert_not_called()
+
+    def test_seed_data_without_gps_proceeds(self, cot):
+        v = _fake_vehicle()
+        with patch.object(cot, "_fetch_initial_data", return_value={"drive_state": {}}):
+            assert cot._seed_initial_position(v) is True  # no save, still proceeds
+
+
+class TestRecheckWakeEdges:
+    def test_vehicle_not_in_list(self, cot):
+        v = _fake_vehicle()
+        cot.vehicle_woken_once = False
+        v._owner.vehicle_list.return_value = [{"id": 99, "state": "asleep"}]
+        cot._recheck_wake(v)
+        v.sync_wake_up.assert_not_called()  # id mismatch -> never matched
+
+    def test_vehicle_online_not_woken(self, cot):
+        v = _fake_vehicle()
+        cot.vehicle_woken_once = False
+        v._owner.vehicle_list.return_value = [{"id": 1, "state": "online"}]
+        cot._recheck_wake(v)
+        v.sync_wake_up.assert_not_called()
+
+    def test_wake_exception_swallowed(self, cot):
+        v = _fake_vehicle()
+        cot.vehicle_woken_once = False
+        v._owner.vehicle_list.return_value = [{"id": 1, "state": "asleep"}]
+        v.sync_wake_up.side_effect = RuntimeError("x")
+        cot._recheck_wake(v)  # must not raise
+        assert cot.vehicle_woken_once is False  # wake failed
+
+    def test_poll_warns_on_missing_autopilot_while_driving(self, cot):
+        v = _fake_vehicle()
+        v.get_vehicle_data.return_value = {
+            "drive_state": {"latitude": 30.0, "longitude": -87.0, "shift_state": "D"},
+            "vehicle_state": {"autopilot_state": None},  # explicitly unavailable
+        }
+        cot._handle_valid_gps = MagicMock()
+        with patch("teslaontarget.tesla_api.time.sleep"):
+            cot._poll_once(v)  # exercises the autopilot-unavailable warning

--- a/tests/test_tesla_api.py
+++ b/tests/test_tesla_api.py
@@ -181,3 +181,56 @@ class TestExtractRelevantData:
         v = {"vehicle_id": "987", "display_name": "X"}  # no id_s
         d = cot.extract_relevant_data({}, v)
         assert d["UID"] == "TESLA-" + hashlib.md5(b"987").hexdigest()[:8]
+
+
+class TestDeadReckoning:
+    def _drive(self, cot, initial_data, times, max_iters=2):
+        """Run dead_reckoning_update with a controlled clock + bounded loop."""
+        cot.send_to_cot = MagicMock()
+        cot.stop_dead_reckoning = MagicMock()
+        cot.stop_dead_reckoning.is_set.side_effect = [False] * (max_iters - 1) + [True]
+        with patch("teslaontarget.tesla_api.time") as t:
+            t.time.side_effect = times
+            t.sleep = MagicMock()
+            cot.dead_reckoning_update(initial_data)
+        return cot
+
+    def test_stationary_resends_same_position(self, cot):
+        data = {"latitude": 30.0, "longitude": -87.0, "speed": 0}
+        # start=1000, timestamp=1001, break-check=1100 (>=9 -> break)
+        self._drive(cot, data, times=[1000, 1001, 1100])
+        cot.send_to_cot.assert_called_once()
+        sent = cot.send_to_cot.call_args[0][0]
+        assert sent["latitude"] == 30.0 and sent["dead_reckoned"] is True
+
+    def test_speed_none_treated_as_stationary(self, cot):
+        data = {"latitude": 30.0, "longitude": -87.0, "speed": None}
+        self._drive(cot, data, times=[1000, 1001, 1100])
+        cot.send_to_cot.assert_called_once()
+
+    def test_moving_advances_position(self, cot):
+        data = {"latitude": 30.0, "longitude": -87.0, "speed": 60, "heading": 90}
+        self._drive(cot, data, times=[1000, 1001, 1100])
+        sent = cot.send_to_cot.call_args[0][0]
+        # heading 90 (east) -> longitude moves, latitude ~unchanged
+        assert sent["dead_reckoned"] is True
+        assert sent["longitude"] != -87.0
+
+    def test_continues_until_stop_when_under_max_duration(self, cot):
+        data = {"latitude": 30.0, "longitude": -87.0, "speed": 0}
+        # break-check 1002-1000=2 < 9 -> no break -> next is_set True -> exit
+        self._drive(cot, data, times=[1000, 1001, 1002], max_iters=2)
+        cot.send_to_cot.assert_called_once()
+
+    def test_moving_with_none_heading_and_no_break(self, cot):
+        # heading None -> 0; time under max_duration so it loops to the stop event
+        data = {"latitude": 30.0, "longitude": -87.0, "speed": 60, "heading": None}
+        self._drive(cot, data, times=[1000, 1001, 1002], max_iters=2)
+        cot.send_to_cot.assert_called_once()
+
+    def test_zero_coordinate_breaks_immediately(self, cot):
+        # latitude 0 formats fine for the log but is falsy -> "no valid position"
+        data = {"latitude": 0, "longitude": -87.0, "speed": 0}
+        # max_iters=2 so the loop body runs once and hits the else/break
+        self._drive(cot, data, times=[1000, 1001], max_iters=2)
+        cot.send_to_cot.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,6 @@ import math
 import pytest
 from hypothesis import HealthCheck, given, settings, strategies as st
 
-# Robust under mutmut/coverage instrumentation (no deadline; allow class-method
-# property tests to run under different executors across mutation runs).
-_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 from teslaontarget.utils import (
     calculate_distance,
@@ -17,6 +14,10 @@ from teslaontarget.utils import (
     mph_to_ms,
     celsius_to_fahrenheit,
 )
+
+# Robust under mutmut/coverage instrumentation (no deadline; allow class-method
+# property tests to run under different executors across mutation runs).
+_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 # ---- coordinates (lat in [-90,90], lon in [-180,180]) ----
 _lats = st.floats(min_value=-89.9, max_value=89.9, allow_nan=False, allow_infinity=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,11 @@ import json
 import math
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import HealthCheck, given, settings, strategies as st
+
+# Robust under mutmut/coverage instrumentation (no deadline; allow class-method
+# property tests to run under different executors across mutation runs).
+_PROP = settings(deadline=None, suppress_health_check=[HealthCheck.differing_executors])
 
 from teslaontarget.utils import (
     calculate_distance,
@@ -33,11 +37,13 @@ class TestCalculateDistance:
         d = calculate_distance(0.0, 0.0, 0.0, 90.0)
         assert d == pytest.approx(2 * math.pi * 6371e3 / 4, rel=0.001)
 
+    @_PROP
     @given(_lats, _lons, _lats, _lons)
     def test_symmetry(self, a, b, c, d):
         assert calculate_distance(a, b, c, d) == pytest.approx(
             calculate_distance(c, d, a, b), rel=1e-9, abs=1e-6)
 
+    @_PROP
     @given(_lats, _lons, _lats, _lons)
     def test_non_negative_and_bounded(self, a, b, c, d):
         dist = calculate_distance(a, b, c, d)
@@ -45,6 +51,7 @@ class TestCalculateDistance:
         # Can never exceed half the Earth's circumference (antipodal max).
         assert dist <= math.pi * 6371e3 + 1
 
+    @_PROP
     @given(_lats, _lons)
     def test_identity_is_zero(self, lat, lon):
         assert calculate_distance(lat, lon, lat, lon) == pytest.approx(0.0, abs=1e-3)
@@ -55,6 +62,7 @@ class TestUnitConversions:
         assert meters_to_feet(1.0) == pytest.approx(3.28084)
         assert meters_to_feet(0) == 0
 
+    @_PROP
     @given(st.floats(min_value=0, max_value=1e6, allow_nan=False))
     def test_meters_to_feet_scale(self, m):
         assert meters_to_feet(m) == pytest.approx(m * 3.28084)
@@ -66,6 +74,7 @@ class TestUnitConversions:
     def test_mph_to_ms_falsy_returns_zero(self, falsy):
         assert mph_to_ms(falsy) == 0
 
+    @_PROP
     @given(st.floats(min_value=0.001, max_value=1000, allow_nan=False))
     def test_mph_to_ms_positive_is_scaled(self, mph):
         assert mph_to_ms(mph) == pytest.approx(mph * 0.44704)
@@ -78,6 +87,7 @@ class TestUnitConversions:
     def test_celsius_to_fahrenheit_none(self):
         assert celsius_to_fahrenheit(None) is None
 
+    @_PROP
     @given(st.floats(min_value=-273, max_value=1000, allow_nan=False))
     def test_celsius_to_fahrenheit_formula(self, c):
         assert celsius_to_fahrenheit(c) == pytest.approx((c * 9 / 5) + 32)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,111 @@
+"""Tests for teslaontarget.utils — pure helpers (math, unit conversion, JSON IO)."""
+import json
+import math
+
+import pytest
+from hypothesis import given, strategies as st
+
+from teslaontarget.utils import (
+    calculate_distance,
+    load_json_file,
+    save_json_file,
+    meters_to_feet,
+    mph_to_ms,
+    celsius_to_fahrenheit,
+)
+
+# ---- coordinates (lat in [-90,90], lon in [-180,180]) ----
+_lats = st.floats(min_value=-89.9, max_value=89.9, allow_nan=False, allow_infinity=False)
+_lons = st.floats(min_value=-179.9, max_value=179.9, allow_nan=False, allow_infinity=False)
+
+
+class TestCalculateDistance:
+    def test_zero_distance_for_identical_points(self):
+        assert calculate_distance(30.0, -87.0, 30.0, -87.0) == pytest.approx(0.0, abs=1e-6)
+
+    def test_known_distance_one_degree_latitude(self):
+        # One degree of latitude is ~111.19 km along a meridian.
+        d = calculate_distance(0.0, 0.0, 1.0, 0.0)
+        assert d == pytest.approx(111195, rel=0.001)
+
+    def test_equator_quarter_circumference(self):
+        # 0E -> 90E on the equator is a quarter of Earth's circumference.
+        d = calculate_distance(0.0, 0.0, 0.0, 90.0)
+        assert d == pytest.approx(2 * math.pi * 6371e3 / 4, rel=0.001)
+
+    @given(_lats, _lons, _lats, _lons)
+    def test_symmetry(self, a, b, c, d):
+        assert calculate_distance(a, b, c, d) == pytest.approx(
+            calculate_distance(c, d, a, b), rel=1e-9, abs=1e-6)
+
+    @given(_lats, _lons, _lats, _lons)
+    def test_non_negative_and_bounded(self, a, b, c, d):
+        dist = calculate_distance(a, b, c, d)
+        assert dist >= 0
+        # Can never exceed half the Earth's circumference (antipodal max).
+        assert dist <= math.pi * 6371e3 + 1
+
+    @given(_lats, _lons)
+    def test_identity_is_zero(self, lat, lon):
+        assert calculate_distance(lat, lon, lat, lon) == pytest.approx(0.0, abs=1e-3)
+
+
+class TestUnitConversions:
+    def test_meters_to_feet_known(self):
+        assert meters_to_feet(1.0) == pytest.approx(3.28084)
+        assert meters_to_feet(0) == 0
+
+    @given(st.floats(min_value=0, max_value=1e6, allow_nan=False))
+    def test_meters_to_feet_scale(self, m):
+        assert meters_to_feet(m) == pytest.approx(m * 3.28084)
+
+    def test_mph_to_ms_known(self):
+        assert mph_to_ms(100) == pytest.approx(44.704)
+
+    @pytest.mark.parametrize("falsy", [0, 0.0, None])
+    def test_mph_to_ms_falsy_returns_zero(self, falsy):
+        assert mph_to_ms(falsy) == 0
+
+    @given(st.floats(min_value=0.001, max_value=1000, allow_nan=False))
+    def test_mph_to_ms_positive_is_scaled(self, mph):
+        assert mph_to_ms(mph) == pytest.approx(mph * 0.44704)
+
+    def test_celsius_to_fahrenheit_known(self):
+        assert celsius_to_fahrenheit(0) == 32
+        assert celsius_to_fahrenheit(100) == 212
+        assert celsius_to_fahrenheit(-40) == -40
+
+    def test_celsius_to_fahrenheit_none(self):
+        assert celsius_to_fahrenheit(None) is None
+
+    @given(st.floats(min_value=-273, max_value=1000, allow_nan=False))
+    def test_celsius_to_fahrenheit_formula(self, c):
+        assert celsius_to_fahrenheit(c) == pytest.approx((c * 9 / 5) + 32)
+
+
+class TestJsonIO:
+    def test_save_then_load_roundtrip(self, tmp_path):
+        p = tmp_path / "data.json"
+        payload = {"a": 1, "b": [1, 2, 3], "c": "x"}
+        assert save_json_file(str(p), payload) is True
+        assert load_json_file(str(p)) == payload
+
+    def test_load_missing_file_returns_none(self, tmp_path):
+        assert load_json_file(str(tmp_path / "nope.json")) is None
+
+    def test_load_malformed_json_returns_none(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("{not valid json")
+        assert load_json_file(str(p)) is None
+
+    def test_save_to_unwritable_path_returns_false(self, tmp_path):
+        # Parent directory does not exist -> open() raises -> caught -> False.
+        bad = tmp_path / "missing_dir" / "data.json"
+        assert save_json_file(str(bad), {"a": 1}) is False
+
+    def test_save_writes_indented_json(self, tmp_path):
+        p = tmp_path / "out.json"
+        save_json_file(str(p), {"k": "v"})
+        text = p.read_text()
+        assert json.loads(text) == {"k": "v"}
+        assert "\n" in text  # indent=2 produces multiline output

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "certifi"
@@ -101,12 +106,113 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/91/0a7c28934e50d8ac9a7b117712d176f2953c3170bccced5eaacfa3e96175/coverage-7.14.3.tar.gz", hash = "sha256:1a7563a443f3d53fdeb040ec8c9f7466aed7ca3dc5891aa09d3ca3625fa4387f", size = 924398, upload-time = "2026-06-22T23:10:25.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/24/efb17eb94018dd3415d0e8a76a4786a866e8964aa9c50f033399d23939c2/coverage-7.14.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e574801e1d643561594aa021206c46d80b257e9853087090ba97bed8b0a509d3", size = 220501, upload-time = "2026-06-22T23:08:02.182Z" },
+    { url = "https://files.pythonhosted.org/packages/76/93/32f1bfca6cdd34259c8af42820a034b7a28dfb44969a13ed38c17e0ba5b0/coverage-7.14.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f82b6bb7d75a2613e85d07cefa3a8c973d0544a8993337f6e2728e4a1e94c305", size = 221008, upload-time = "2026-06-22T23:08:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/88/0d0f974855ff905d15a64f7873d00bdc4182e2736267486c6634f4af293c/coverage-7.14.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2335ea5fed26af2e831094964fa3f8fae60b45f7e37fcc2d3b615b2add3ad87", size = 251420, upload-time = "2026-06-22T23:08:05.211Z" },
+    { url = "https://files.pythonhosted.org/packages/39/7f/117dd2ec65e4140576f8ef991d88220f9b806769f7a8c20e0550c0f924e2/coverage-7.14.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fbb8c3a98e779013786ae01d229662aeacbc77100efbd3f2f245219ace5af700", size = 253331, upload-time = "2026-06-22T23:08:06.672Z" },
+    { url = "https://files.pythonhosted.org/packages/87/55/f0bd6d6538e3f16829fb8a44b6c0d2fe9da638bbfdd6a20f8b5da8f4fa81/coverage-7.14.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac082660de8f429ba0ea363595abb838998570b9a7546777c60f413ab902bbde", size = 255441, upload-time = "2026-06-22T23:08:08.208Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/98/aa71f7879019c846a8a9662579ea4484b0202cf1e252ffeed647075e7eca/coverage-7.14.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8ac012839ff7e396030f1e94e10553a431d14e4de2ab65cb3acb72bbd5628ca2", size = 257398, upload-time = "2026-06-22T23:08:09.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/4f/5fd367e59844190f5965015d7bee899e67a89d13eb2760118479bf836f2f/coverage-7.14.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5952f8c1bda2a5347154450379316e6dfa4d934d62ca35f6784451e6f55074fb", size = 251558, upload-time = "2026-06-22T23:08:11.37Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/de/5383a6ee5a6376701fe07d980fa8e4a66c0c377fead16712720340d701a3/coverage-7.14.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8cf0f2509acb4619e2471a1951089054dd58ebea7a912066d2ea56dd4c24ca4a", size = 253134, upload-time = "2026-06-22T23:08:13.04Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/09542b1a99f788e3daec7f0fadc288821e71aca9ea298d51bfa1ba79fed5/coverage-7.14.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2e41fd3aab806770008279a93879b0924b16247e09ab537c043d08bbca53b4ab", size = 251195, upload-time = "2026-06-22T23:08:14.606Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9d/722fe8c13f0fbb064491b9e8656e56a606286792e5068c47ca1042e773e8/coverage-7.14.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f0a47095963cfe054e0df178daca95aec21e680d6076da807c3add28dfe920f7", size = 254959, upload-time = "2026-06-22T23:08:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/58/943627179ff1d82da9e54d0a5b0bb907bb19cf19515599ccd921de50b469/coverage-7.14.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a090cbf9521e78ffdb2fcf448b72902afe9f5923ff6a12d5c0d0120200348af9", size = 250914, upload-time = "2026-06-22T23:08:18.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d4/803efcbf9ae5567454a0c71e983589529448e2704ee0da2dc0163d482f18/coverage-7.14.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4d310baf69a4fbe8a098ce727e4808a34866ac718a6f759ae659cbd3221358bc", size = 251824, upload-time = "2026-06-22T23:08:19.704Z" },
+    { url = "https://files.pythonhosted.org/packages/32/79/3f78ea9563132746eed5cecb75d2e576f9d8fec45a47242b5ae0950b82a3/coverage-7.14.3-cp311-cp311-win32.whl", hash = "sha256:74fdd718d88fe144f4579b8747873a07ec3f04cb837d5faec5a25d9e22fa31a8", size = 222594, upload-time = "2026-06-22T23:08:21.311Z" },
+    { url = "https://files.pythonhosted.org/packages/85/22/9ebbc5a2ab42ac5d0eea1f48648629e1de9bbe41ec243ed6b93d55a5a53f/coverage-7.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:cc96aa922e21d4bc5d5ed3c915cef27dfcbc13686f47d5e378d647fbfba655a2", size = 223073, upload-time = "2026-06-22T23:08:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/71/af/69d5fcc16cb555153f99cec5467922f226be0369f7335a9506856d2a7bd0/coverage-7.14.3-cp311-cp311-win_arm64.whl", hash = "sha256:c66f9f9d4f1e9712eb9b1de5310f881d4e2188cfcba5065e1a8490f38687f2c4", size = 222617, upload-time = "2026-06-22T23:08:25.054Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b0/8a911f6ffe6974dac4df95b468ab9a2899d0e59f0f99a489afeec39f00bc/coverage-7.14.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3d74ff26299c4879ce3a4d826f9d3d4d556fd285fde7bbce3c0ef5a8ab1cec24", size = 220672, upload-time = "2026-06-22T23:08:26.621Z" },
+    { url = "https://files.pythonhosted.org/packages/36/16/0fc0cb52538783dbbae0934b834f5a58fd5354380ee6cad4a07b15dc845d/coverage-7.14.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:96150a9cf3468ea20f0bc5d0e21b3df8972c31480ef90fa7614b773cc6429665", size = 221035, upload-time = "2026-06-22T23:08:28.372Z" },
+    { url = "https://files.pythonhosted.org/packages/77/e2/421ccfbb48335ac49e93301478cf5d623b0c2bf1c0cadd8e2b2fc6c0c710/coverage-7.14.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:27d07a46500ba23515b838dbcf52512026af04090755cf6cc64166d88c9b9a1a", size = 252540, upload-time = "2026-06-22T23:08:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c2/05b8c890097c61a7f4406b35396b997a635200ded0339eda83dfbe526c5f/coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:621e13c6108234d7960aaf5762ab5c3c00f33c30c15af06dcbff0c73bf112727", size = 255274, upload-time = "2026-06-22T23:08:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/b6d9efe447f8ba3c3c854195f326bd64c54b907d936cd2fdebf8767ec72e/coverage-7.14.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b60ca6d8af70473491a15a343cbabab2e8f9ea66a4376e81c7aa24876a6f977", size = 256389, upload-time = "2026-06-22T23:08:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/f26e50acc429e608bc534ac06f0a3c169019c798178ec5e9de3dbc0df9c9/coverage-7.14.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c90a7cdd5e380e1ce02f19792e2ac2fbfbf177e35a27e69fd3e873b30d895c0c", size = 258648, upload-time = "2026-06-22T23:08:35.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a2/01c1fabf816c8e1dae197e258edf878a3d3ddc86fbda34b76e5794277d8f/coverage-7.14.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d788e5fd55347eef06ca0732c77d04a264de67e8ff24631270cdff3767a60cf", size = 252949, upload-time = "2026-06-22T23:08:37.562Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c6/941166dd79c31fd44a13063780ae8d552eee0089a0a0930b9bdb7df554ed/coverage-7.14.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62c7f79db2851c95ef020e5d28b97afde3daf9f7febcd35b53e05638f729063f", size = 254310, upload-time = "2026-06-22T23:08:39.174Z" },
+    { url = "https://files.pythonhosted.org/packages/10/31/80b1fd028201a961033ce95be3cd1e39e521b3762e6b4a1ac1616cb291e7/coverage-7.14.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:90f7608aeb5d9b60b523b9fb2a4ee1973867cc4865a3f26fe6c7577073b70205", size = 252453, upload-time = "2026-06-22T23:08:40.84Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/c3d9addd94c4b524f3f4af0232075f5fe7170ce99a1386edff803e5934db/coverage-7.14.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1e3b91f9c4740aeb571ecf82e5e8d8e4ab62d34fcb5a5d4e5baa38c6f7d2857c", size = 256522, upload-time = "2026-06-22T23:08:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/91/14/e5a0575f73795af3a7a9ae13dadf812e17d32422896839987dc3f86947e1/coverage-7.14.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c946099774a7699de03cbd0ff0a64e21aed4525eed9d959adde4afe6d15758ef", size = 252023, upload-time = "2026-06-22T23:08:44.243Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9b/9652ee531937ce3b8a63a8896885b2b4a2d56adc30e53c9540c666286d88/coverage-7.14.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:16b206e521feb8b7133a45754643dead0538489cf8b783b90cf5f4e3299625fd", size = 253893, upload-time = "2026-06-22T23:08:46.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/05/42678841c8c38e4b08bdfc48269f5a16dfbf5806000fe6a89b4cece3c691/coverage-7.14.3-cp312-cp312-win32.whl", hash = "sha256:ea3169c7116eb6cdf7608c6c7da9ecfcb3da40688e3a510fac2d1d2bafd6dc35", size = 222734, upload-time = "2026-06-22T23:08:47.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/87/07a4fcee55177a25f1b52331a8e92cf4f2c53b1a9c75ce2981fd59c684ad/coverage-7.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:7ea52fc08f007bcc494d4bb3df3851e95843d881860ba38fe2c64dc100db5e7d", size = 223266, upload-time = "2026-06-22T23:08:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/34/2b8b66a989282ea7b370beb49f50bab29470dc30bb0b03935b6b802782f7/coverage-7.14.3-cp312-cp312-win_arm64.whl", hash = "sha256:8cec0ad652ec57790970d817490105bd917d783c2f7b38d6b58a0ca312e1a336", size = 222655, upload-time = "2026-06-22T23:08:51.766Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/83/7fefbf5df23ed2b7f489907564a7b34b9b07098128e12e0fdfa92626e456/coverage-7.14.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47968988b367990ae4ab17523790c38cd125e02c6bfd379b6022be2d40bdc38c", size = 220699, upload-time = "2026-06-22T23:08:53.522Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e6/38c3653ff6d56d704b29241362387ca824e38e15b76fdcb7096538195790/coverage-7.14.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee68f5c34812780f3a7063382c0a9fcbb99985b7ddcdcaa626e4f3fb2e0783a", size = 221068, upload-time = "2026-06-22T23:08:55.571Z" },
+    { url = "https://files.pythonhosted.org/packages/20/86/4f5c45d51c5cd10a128933f0fd235393c9146abbfd2ce2dfa68b3267ead3/coverage-7.14.3-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fa9e5c6857a7e80fa22ace5cf3550ae392bbfc322f1d8dd2d2d5a8be38cec027", size = 252060, upload-time = "2026-06-22T23:08:57.464Z" },
+    { url = "https://files.pythonhosted.org/packages/82/50/dfce42eff2cecabcd5a9bbad5489449c87db3415f408d23ffee417ce01f6/coverage-7.14.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:98a0859b0e98e43e1178a9402e19c8127766b14f7109a374d976e5a62c0e5c73", size = 254657, upload-time = "2026-06-22T23:08:59.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d2/639ceb1bc8038fd0d66768278d5dc22df3391918b8278c2a21aa2602a531/coverage-7.14.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69918344541ed9c8368566c2adc03c0e33d4550d7faa87d1b35e49b6a3286ea9", size = 255892, upload-time = "2026-06-22T23:09:01.291Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/96/002094a10e113512500dc1e10430a449417e17b0f90f7d496bcb820208b7/coverage-7.14.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b7f300ac92cd4b570724c8ffbbd0c130fee298d2447f41d5a3abf58976fae1de", size = 258026, upload-time = "2026-06-22T23:09:03.017Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ec/286a5d2fad9c4bee59bd724feeb7d5bf8303c6c9200b51d1dd945a9c72b0/coverage-7.14.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:11a7ec9f97ab950f4c5af62229befc7faf208fdbc0116d3902d7e306cf2c5abd", size = 252285, upload-time = "2026-06-22T23:09:04.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7d/a17753a0b12dd48d0d50f5fab079ad99d3be1eac790494d89f3a417ca0b9/coverage-7.14.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a571bd889cd36c5922ce8e42e059f9d37d02301531d11374afa4c87a578625d5", size = 254023, upload-time = "2026-06-22T23:09:06.513Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/a76c6ceba6a2c313f905310abf2701d534cada22d372db11731831e9e209/coverage-7.14.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:de76caefc8deabb0dd1678b6a980be97d14c8d87e213ac194dbf8b09e96d63fb", size = 251989, upload-time = "2026-06-22T23:09:08.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/39/353013a75fec0fb49f7553519f9d52b4441e902e5178c93f38eb6c07cedb/coverage-7.14.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d20a15c622194234161535459affa8f7905830391c9ccfa060d495dbfe3a1c7f", size = 256144, upload-time = "2026-06-22T23:09:10.369Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0e/613878555d734def11c5b20a2701a15cb3781b9e9ea749da27c5f436e928/coverage-7.14.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b488bd4b23397db62e7a9459129d01ff06a846582a732efd24834b24a6ada498", size = 251808, upload-time = "2026-06-22T23:09:12.057Z" },
+    { url = "https://files.pythonhosted.org/packages/af/76/359c058c9cfdcf1e8b107663881225b03b364a320017eda24a2a66e55102/coverage-7.14.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6a3693b4153394d265f44fb855fdc80e72403024d4d6f91c4871b334d028e4e0", size = 253579, upload-time = "2026-06-22T23:09:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/d9/4ba2f060933a30ebe363cef9f67a365b0a317e580c0d5d9169d56a73ef1c/coverage-7.14.3-cp313-cp313-win32.whl", hash = "sha256:338b19131ab1a6b767b462bfcbaa692e7ae22f24463e39d49b02a83410ff6b37", size = 222741, upload-time = "2026-06-22T23:09:15.636Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e8/196ebc25d8f34c06d43a6e9c8513c9266ef8dbf3b5672beb1a00cf5e29fa/coverage-7.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:b3d77f7f196abdef7e01415de1bce09f216189e83e58159cfeef2b92d0464994", size = 223283, upload-time = "2026-06-22T23:09:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/51d2aac6417523a286f10fb25f09eb9518a84df9f1151e93ff6871f34849/coverage-7.14.3-cp313-cp313-win_arm64.whl", hash = "sha256:e6230e688c7c3e65cedd41a774eb4ec221adc6bfee13768231015b702d5e4150", size = 222678, upload-time = "2026-06-22T23:09:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/61/56/14e3b97facbfa1304dd19e676e26599ad359f04714bed32f7f1c5a88efdc/coverage-7.14.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:605ab2b566a22bd94834529d66d295c364aba84afd3e5498285c7a524017b1fc", size = 220741, upload-time = "2026-06-22T23:09:21.616Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a3c2134809e80fac091bfed18a6991b5a5eb5df5ae32b17ac4f4f99864b73dd7", size = 221068, upload-time = "2026-06-22T23:09:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f0/3f8421b20d9c4fcd39be9a8ca3c3fda8bc204b44efbd09fede153afd3e2f/coverage-7.14.3-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c02efd507227bde9969cab0db8f48890eb3b5dcad6afac57a4792df4133543ce", size = 252117, upload-time = "2026-06-22T23:09:25.458Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1bb93c2aa61d2a5b38f1526546d95cf4132cb681e541a337bf8dfd092be816e5", size = 254622, upload-time = "2026-06-22T23:09:27.523Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/ec6de51ae7493b92a1cf74d1b763121c29636759167e2a593ba4db5881e4/coverage-7.14.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f502e948e03e866538048bba081c075caaa62e5bda6ea5b7432e45f587eb462a", size = 255968, upload-time = "2026-06-22T23:09:29.43Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/c8bfc77823f42b4664fb25842f13b567022f6f84a4c83c8ecbb16734b7cb/coverage-7.14.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9973ef2463f8e6cfb61a6324126bb3e17d67a85f22f58d856e583ea2e3ca6501", size = 258284, upload-time = "2026-06-22T23:09:31.397Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/15/1d1b242027124a32b26ef01f82018b8c4ef34ef174aa6aeba7b1eeef48e8/coverage-7.14.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9be4e7d4c5ca0427889f8f9d614bd630c2be741b1de7699bca3b2b6c0e41003e", size = 252143, upload-time = "2026-06-22T23:09:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/d2a9842fd2a5d7d27f1ac851c043a734a494ad75402c5331db3da79ed691/coverage-7.14.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a574912f3bde4b0619f6e97d01aa590b70998859244793769eb3a6df78ee56d3", size = 253976, upload-time = "2026-06-22T23:09:35.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/30/e1600ddf7e226db5558bb5323d2186fff00f505c4b764643ec89ce5d8175/coverage-7.14.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:e343fb086c9cd780b38622fea7c369acd64c1a0724312149b5d769c387a2b1f5", size = 251942, upload-time = "2026-06-22T23:09:37.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/2c/9159de64f9dd648e324328d588a44cfab1e331eb5259ce1141afe2a92dfb/coverage-7.14.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:3c68df8e61f1e09633fefc7538297145623957a048534368c9d212782aa5e845", size = 256220, upload-time = "2026-06-22T23:09:39.165Z" },
+    { url = "https://files.pythonhosted.org/packages/91/67/b7f536cc2c124f48e91b22fbb741d2261f4e3d310faf6f76007f47566e5d/coverage-7.14.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3e5b550a128419373c2f6cec28a244207013ef15f5cbcff6a5ca09d1dfaaf027", size = 251756, upload-time = "2026-06-22T23:09:41.056Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ec/f3718038e2d4860c715a55428377ca7f6c75872caf98cabd982e1d76967d/coverage-7.14.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2bfc4dd0a912329eccc7484a7d0b2a38032b38c40663b1e1ac595f10c457954b", size = 253413, upload-time = "2026-06-22T23:09:43.306Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a5/91f11efeef89b3cc9b30461128db15b0511ef813ab889a7b7ab636b3a497/coverage-7.14.3-cp314-cp314-win32.whl", hash = "sha256:0423d64c013057a06e70f070f073cec4b0cbc7d2b27f3c7007292f2ff1d52965", size = 222946, upload-time = "2026-06-22T23:09:45.261Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fd/98ac9f524d9ec378de831c034dbdeb544ca7ef7d2d9c9996daf232a037fd/coverage-7.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:92c22e19ce64ca3f2ad751f16f14df1468b4c231bd6af97185063a9c292a0cb3", size = 223436, upload-time = "2026-06-22T23:09:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a0/7cd612d650a772a0ae80144443406bf61981c896c3d57c9e6e79fb2cdbd1/coverage-7.14.3-cp314-cp314-win_arm64.whl", hash = "sha256:41de778bd41780586e2b04912079c73089ab5d839624e28db3bdb26de638da92", size = 222861, upload-time = "2026-06-22T23:09:49.384Z" },
+    { url = "https://files.pythonhosted.org/packages/55/57/017353fab573779c0d00448e47d102edd36c792f7b6f233a4d89a7a08384/coverage-7.14.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8427f370ca67db4c975d2a26acfc0e5783ca0b52444dbc50278ace0f35445949", size = 221474, upload-time = "2026-06-22T23:09:51.417Z" },
+    { url = "https://files.pythonhosted.org/packages/69/92/90cf1f1a5c468a9c1b7ba2716e0e205293ad9b02f5f573a6de4318b15ba1/coverage-7.14.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d8e88f335544a47e22ae2e45b344772925ec65166555c958720d5ed971880891", size = 221738, upload-time = "2026-06-22T23:09:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/4df964fa539f8399fd7679c09c472d73744de334686fd3f01e3a2465ce4e/coverage-7.14.3-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:beaab199b9e5ceaf5a225e16a9d4df136f2a1eae0a5c20de1e277c8a5225f388", size = 263101, upload-time = "2026-06-22T23:09:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/e5d33b2576ae3bf2be2058cd1cae57774b61e400f2c3c58f3783dc2ffb4a/coverage-7.14.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3ff255799f5a1676c71c1c32ec01fd043aa09d57b3d95764b24992757184784", size = 265225, upload-time = "2026-06-22T23:09:57.904Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/e52419afe391a39ba27fdefaf0737d8e34bf03faef6ab3b3006545bbd0d0/coverage-7.14.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:878832eaac515b62decfa76965aed558775f86bf1fc8cca76993c0c84ae31aed", size = 267643, upload-time = "2026-06-22T23:09:59.938Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/f2625d8d5006b6b20fba5afaef00b24a763fe96476ea798a3076cbc1f84e/coverage-7.14.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:611e62cb9386096d81b63e0a05330750268617231e7bd598e1fe77482a2c58a5", size = 268762, upload-time = "2026-06-22T23:10:01.943Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bf/908024006bba57127354d74e938954b9c3cd765cc2e0412dc9c37b415cda/coverage-7.14.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:02c41de2a88011b893050fc9830267d927a50a215f7ad5ec17349db7090ccf26", size = 262208, upload-time = "2026-06-22T23:10:03.954Z" },
+    { url = "https://files.pythonhosted.org/packages/34/a0/d4f9296441b909817442fdb26bd77a698f08272ec683a7394b00eb2e47a0/coverage-7.14.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:526ce9721116af23b1065089f0b75046fe521e7772ab94b641cd66b7a0421889", size = 265096, upload-time = "2026-06-22T23:10:05.936Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/da/4ae4f3f4e477b56a4ce1e5c48a35eff38a94b50130ce5bdc897024741cfc/coverage-7.14.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e4ed44705ca4bead6fc977a8b741f2145608289b33c8a9b42a95d0f15aedbf4d", size = 262699, upload-time = "2026-06-22T23:10:07.973Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/7a/6927148073ff32856d78baa77b4ddc07a9be7e90020f9db0661c4ca523a1/coverage-7.14.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2415902f385a23dcc4ccd26e0ba803249a169af6a930c003a4c715eeb9a5444e", size = 266433, upload-time = "2026-06-22T23:10:10.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a7/774f658dbe9c4c3f5daa86a87e0459ac3832e4e3cc67affe078547f727b9/coverage-7.14.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b75ee850fc2d7c831e883220c445b035f2224de2ba6103f1e56dbd237ab913f7", size = 261547, upload-time = "2026-06-22T23:10:12.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/14/a0c18c0376c43cbf973f43ef6ca20019c950597180e6396232f7b6a27102/coverage-7.14.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dc9b4e35e7c3920e925ba7f14886fd5fbe481232754624e832ddba66c7535635", size = 263859, upload-time = "2026-06-22T23:10:14.492Z" },
+    { url = "https://files.pythonhosted.org/packages/10/ac/43a3d0f460af524b131a6191805bc5d18b806ab4e828fbf82e8c8c3af446/coverage-7.14.3-cp314-cp314t-win32.whl", hash = "sha256:7b27c822a8161afbe48e99f1adfb098d270ae7e0f7d7b0555ce110529bdb69cc", size = 223250, upload-time = "2026-06-22T23:10:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5f/d5e5c56b0712e96ce8f69fe7dbf229ff938b437bc50862743c8a0d2cea84/coverage-7.14.3-cp314-cp314t-win_amd64.whl", hash = "sha256:39e1dbbb6ff2c338e0196a482558a792a1de3aa64261196f5cdb3da016ad9cda", size = 224082, upload-time = "2026-06-22T23:10:19.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/35/947cbd5be1d3bcbbdc43d6791de8a56c6501903311d42915ae06a82815f0/coverage-7.14.3-cp314-cp314t-win_arm64.whl", hash = "sha256:68520c90babfa2d560eca6d497921ed3a4f469623bd709733124491b2aa8ef3f", size = 223400, upload-time = "2026-06-22T23:10:21.24Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e3/a0aa32bfa3a081951f60a23bc0e7b512891ef0eecda1153cf1d8ba36c6b1/coverage-7.14.3-py3-none-any.whl", hash = "sha256:fb7e18afb6e903c1a92401a2f0501ac277dca527bb9ca6fe1f691a8a0026a0e8", size = 212469, upload-time = "2026-06-22T23:10:23.405Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -121,6 +227,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.155.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/55/983b6bc1b6b343a5ff6020388f9d0680ab477be59a731517e6c4a0387100/hypothesis-6.155.7.tar.gz", hash = "sha256:d8d6091753d0669db3c90c5e5b346cb37c72f3dd9378c8413acb1fd5da63f7ea", size = 478291, upload-time = "2026-06-21T05:54:31.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/f8/c151e196d4f397ed9436a071e52666c70a2f021138dea828b0a461e245db/hypothesis-6.155.7-py3-none-any.whl", hash = "sha256:9f634bdb1f9e9b8ab6ba09431cf2deedb750c96978125a6fb3c5a0f6c6db4131", size = 544762, upload-time = "2026-06-21T05:54:29.506Z" },
 ]
 
 [[package]]
@@ -142,12 +260,139 @@ wheels = [
 ]
 
 [[package]]
+name = "libcst"
+version = "1.8.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "python_full_version != '3.13.*'" },
+    { name = "pyyaml-ft", marker = "python_full_version == '3.13.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/cd/337df968b38d94c5aabd3e1b10630f047a2b345f6e1d4456bd9fe7417537/libcst-1.8.6.tar.gz", hash = "sha256:f729c37c9317126da9475bdd06a7208eb52fcbd180a6341648b45a56b4ba708b", size = 891354, upload-time = "2025-11-03T22:33:30.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/15/95c2ecadc0fb4af8a7057ac2012a4c0ad5921b9ef1ace6c20006b56d3b5f/libcst-1.8.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3649a813660fbffd7bc24d3f810b1f75ac98bd40d9d6f56d1f0ee38579021073", size = 2211289, upload-time = "2025-11-03T22:32:04.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c3/7e1107acd5ed15cf60cc07c7bb64498a33042dc4821874aea3ec4942f3cd/libcst-1.8.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0cbe17067055829607c5ba4afa46bfa4d0dd554c0b5a583546e690b7367a29b6", size = 2092927, upload-time = "2025-11-03T22:32:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ff/0d2be87f67e2841a4a37d35505e74b65991d30693295c46fc0380ace0454/libcst-1.8.6-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:59a7e388c57d21d63722018978a8ddba7b176e3a99bd34b9b84a576ed53f2978", size = 2237002, upload-time = "2025-11-03T22:32:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/8c4a1b35c7894ccd7d33eae01ac8967122f43da41325223181ca7e4738fe/libcst-1.8.6-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:b6c1248cc62952a3a005792b10cdef2a4e130847be9c74f33a7d617486f7e532", size = 2301048, upload-time = "2025-11-03T22:32:08.869Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8b/d1aa811eacf936cccfb386ae0585aa530ea1221ccf528d67144e041f5915/libcst-1.8.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6421a930b028c5ef4a943b32a5a78b7f1bf15138214525a2088f11acbb7d3d64", size = 2300675, upload-time = "2025-11-03T22:32:10.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/6b/7b65cd41f25a10c1fef2389ddc5c2b2cc23dc4d648083fa3e1aa7e0eeac2/libcst-1.8.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6d8b67874f2188399a71a71731e1ba2d1a2c3173b7565d1cc7ffb32e8fbaba5b", size = 2407934, upload-time = "2025-11-03T22:32:11.856Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/8b/401cfff374bb3b785adfad78f05225225767ee190997176b2a9da9ed9460/libcst-1.8.6-cp311-cp311-win_amd64.whl", hash = "sha256:b0d8c364c44ae343937f474b2e492c1040df96d94530377c2f9263fb77096e4f", size = 2119247, upload-time = "2025-11-03T22:32:13.279Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/17/085f59eaa044b6ff6bc42148a5449df2b7f0ba567307de7782fe85c39ee2/libcst-1.8.6-cp311-cp311-win_arm64.whl", hash = "sha256:5dcaaebc835dfe5755bc85f9b186fb7e2895dda78e805e577fef1011d51d5a5c", size = 2001774, upload-time = "2025-11-03T22:32:14.647Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/3c/93365c17da3d42b055a8edb0e1e99f1c60c776471db6c9b7f1ddf6a44b28/libcst-1.8.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0c13d5bd3d8414a129e9dccaf0e5785108a4441e9b266e1e5e9d1f82d1b943c9", size = 2206166, upload-time = "2025-11-03T22:32:16.012Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cb/7530940e6ac50c6dd6022349721074e19309eb6aa296e942ede2213c1a19/libcst-1.8.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1472eeafd67cdb22544e59cf3bfc25d23dc94058a68cf41f6654ff4fcb92e09", size = 2083726, upload-time = "2025-11-03T22:32:17.312Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cf/7e5eaa8c8f2c54913160671575351d129170db757bb5e4b7faffed022271/libcst-1.8.6-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:089c58e75cb142ec33738a1a4ea7760a28b40c078ab2fd26b270dac7d2633a4d", size = 2235755, upload-time = "2025-11-03T22:32:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/55/54/570ec2b0e9a3de0af9922e3bb1b69a5429beefbc753a7ea770a27ad308bd/libcst-1.8.6-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c9d7aeafb1b07d25a964b148c0dda9451efb47bbbf67756e16eeae65004b0eb5", size = 2301473, upload-time = "2025-11-03T22:32:20.499Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4c/163457d1717cd12181c421a4cca493454bcabd143fc7e53313bc6a4ad82a/libcst-1.8.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:207481197afd328aa91d02670c15b48d0256e676ce1ad4bafb6dc2b593cc58f1", size = 2298899, upload-time = "2025-11-03T22:32:21.765Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1d/317ddef3669883619ef3d3395ea583305f353ef4ad87d7a5ac1c39be38e3/libcst-1.8.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:375965f34cc6f09f5f809244d3ff9bd4f6cb6699f571121cebce53622e7e0b86", size = 2408239, upload-time = "2025-11-03T22:32:23.275Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a1/f47d8cccf74e212dd6044b9d6dbc223636508da99acff1d54786653196bc/libcst-1.8.6-cp312-cp312-win_amd64.whl", hash = "sha256:da95b38693b989eaa8d32e452e8261cfa77fe5babfef1d8d2ac25af8c4aa7e6d", size = 2119660, upload-time = "2025-11-03T22:32:24.822Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d0/dd313bf6a7942cdf951828f07ecc1a7695263f385065edc75ef3016a3cb5/libcst-1.8.6-cp312-cp312-win_arm64.whl", hash = "sha256:bff00e1c766658adbd09a175267f8b2f7616e5ee70ce45db3d7c4ce6d9f6bec7", size = 1999824, upload-time = "2025-11-03T22:32:26.131Z" },
+    { url = "https://files.pythonhosted.org/packages/90/01/723cd467ec267e712480c772aacc5aa73f82370c9665162fd12c41b0065b/libcst-1.8.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7445479ebe7d1aff0ee094ab5a1c7718e1ad78d33e3241e1a1ec65dcdbc22ffb", size = 2206386, upload-time = "2025-11-03T22:32:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/b944944f910f24c094f9b083f76f61e3985af5a376f5342a21e01e2d1a81/libcst-1.8.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4fc3fef8a2c983e7abf5d633e1884c5dd6fa0dcb8f6e32035abd3d3803a3a196", size = 2083945, upload-time = "2025-11-03T22:32:28.847Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bd1b2b2b7f153d82301cdaddba787f4a9fc781816df6bdb295ca5f88b7cf/libcst-1.8.6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1a3a5e4ee870907aa85a4076c914ae69066715a2741b821d9bf16f9579de1105", size = 2235818, upload-time = "2025-11-03T22:32:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ab/f5433988acc3b4d188c4bb154e57837df9488cc9ab551267cdeabd3bb5e7/libcst-1.8.6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6609291c41f7ad0bac570bfca5af8fea1f4a27987d30a1fa8b67fe5e67e6c78d", size = 2301289, upload-time = "2025-11-03T22:32:31.812Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/57/89f4ba7a6f1ac274eec9903a9e9174890d2198266eee8c00bc27eb45ecf7/libcst-1.8.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25eaeae6567091443b5374b4c7d33a33636a2d58f5eda02135e96fc6c8807786", size = 2299230, upload-time = "2025-11-03T22:32:33.242Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/0aa693bc24cce163a942df49d36bf47a7ed614a0cd5598eee2623bc31913/libcst-1.8.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04030ea4d39d69a65873b1d4d877def1c3951a7ada1824242539e399b8763d30", size = 2408519, upload-time = "2025-11-03T22:32:34.678Z" },
+    { url = "https://files.pythonhosted.org/packages/db/18/6dd055b5f15afa640fb3304b2ee9df8b7f72e79513814dbd0a78638f4a0e/libcst-1.8.6-cp313-cp313-win_amd64.whl", hash = "sha256:8066f1b70f21a2961e96bedf48649f27dfd5ea68be5cd1bed3742b047f14acde", size = 2119853, upload-time = "2025-11-03T22:32:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ed/5ddb2a22f0b0abdd6dcffa40621ada1feaf252a15e5b2733a0a85dfd0429/libcst-1.8.6-cp313-cp313-win_arm64.whl", hash = "sha256:c188d06b583900e662cd791a3f962a8c96d3dfc9b36ea315be39e0a4c4792ebf", size = 1999808, upload-time = "2025-11-03T22:32:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d3/72b2de2c40b97e1ef4a1a1db4e5e52163fc7e7740ffef3846d30bc0096b5/libcst-1.8.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c41c76e034a1094afed7057023b1d8967f968782433f7299cd170eaa01ec033e", size = 2190553, upload-time = "2025-11-03T22:32:39.819Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/20/983b7b210ccc3ad94a82db54230e92599c4a11b9cfc7ce3bc97c1d2df75c/libcst-1.8.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5432e785322aba3170352f6e72b32bea58d28abd141ac37cc9b0bf6b7c778f58", size = 2074717, upload-time = "2025-11-03T22:32:41.373Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f2/9e01678fedc772e09672ed99930de7355757035780d65d59266fcee212b8/libcst-1.8.6-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:85b7025795b796dea5284d290ff69de5089fc8e989b25d6f6f15b6800be7167f", size = 2225834, upload-time = "2025-11-03T22:32:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0d/7bed847b5c8c365e9f1953da274edc87577042bee5a5af21fba63276e756/libcst-1.8.6-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:536567441182a62fb706e7aa954aca034827b19746832205953b2c725d254a93", size = 2287107, upload-time = "2025-11-03T22:32:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f0/7e51fa84ade26c518bfbe7e2e4758b56d86a114c72d60309ac0d350426c4/libcst-1.8.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f04d3672bde1704f383a19e8f8331521abdbc1ed13abb349325a02ac56e5012", size = 2288672, upload-time = "2025-11-03T22:32:45.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cd/15762659a3f5799d36aab1bc2b7e732672722e249d7800e3c5f943b41250/libcst-1.8.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f04febcd70e1e67917be7de513c8d4749d2e09206798558d7fe632134426ea4", size = 2392661, upload-time = "2025-11-03T22:32:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6b/b7f9246c323910fcbe021241500f82e357521495dcfe419004dbb272c7cb/libcst-1.8.6-cp313-cp313t-win_amd64.whl", hash = "sha256:1dc3b897c8b0f7323412da3f4ad12b16b909150efc42238e19cbf19b561cc330", size = 2105068, upload-time = "2025-11-03T22:32:49.145Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0b/4fd40607bc4807ec2b93b054594373d7fa3d31bb983789901afcb9bcebe9/libcst-1.8.6-cp313-cp313t-win_arm64.whl", hash = "sha256:44f38139fa95e488db0f8976f9c7ca39a64d6bc09f2eceef260aa1f6da6a2e42", size = 1985181, upload-time = "2025-11-03T22:32:50.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/60/4105441989e321f7ad0fd28ffccb83eb6aac0b7cfb0366dab855dcccfbe5/libcst-1.8.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:b188e626ce61de5ad1f95161b8557beb39253de4ec74fc9b1f25593324a0279c", size = 2204202, upload-time = "2025-11-03T22:32:52.311Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2f/51a6f285c3a183e50cfe5269d4a533c21625aac2c8de5cdf2d41f079320d/libcst-1.8.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:87e74f7d7dfcba9efa91127081e22331d7c42515f0a0ac6e81d4cf2c3ed14661", size = 2083581, upload-time = "2025-11-03T22:32:54.269Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/921b1c19b638860af76cdb28bc81d430056592910b9478eea49e31a7f47a/libcst-1.8.6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3a926a4b42015ee24ddfc8ae940c97bd99483d286b315b3ce82f3bafd9f53474", size = 2236495, upload-time = "2025-11-03T22:32:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a8/b00592f9bede618cbb3df6ffe802fc65f1d1c03d48a10d353b108057d09c/libcst-1.8.6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3f4fbb7f569e69fd9e89d9d9caa57ca42c577c28ed05062f96a8c207594e75b8", size = 2301466, upload-time = "2025-11-03T22:32:57.337Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/790d9002f31580fefd0aec2f373a0f5da99070e04c5e8b1c995d0104f303/libcst-1.8.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:08bd63a8ce674be431260649e70fca1d43f1554f1591eac657f403ff8ef82c7a", size = 2300264, upload-time = "2025-11-03T22:32:58.852Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/dc3f10e65bab461be5de57850d2910a02c24c3ddb0da28f0e6e4133c3487/libcst-1.8.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e00e275d4ba95d4963431ea3e409aa407566a74ee2bf309a402f84fc744abe47", size = 2408572, upload-time = "2025-11-03T22:33:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3b/35645157a7590891038b077db170d6dd04335cd2e82a63bdaa78c3297dfe/libcst-1.8.6-cp314-cp314-win_amd64.whl", hash = "sha256:fea5c7fa26556eedf277d4f72779c5ede45ac3018650721edd77fd37ccd4a2d4", size = 2193917, upload-time = "2025-11-03T22:33:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a2/1034a9ba7d3e82f2c2afaad84ba5180f601aed676d92b76325797ad60951/libcst-1.8.6-cp314-cp314-win_arm64.whl", hash = "sha256:bb9b4077bdf8857b2483879cbbf70f1073bc255b057ec5aac8a70d901bb838e9", size = 2078748, upload-time = "2025-11-03T22:33:03.707Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a1/30bc61e8719f721a5562f77695e6154e9092d1bdf467aa35d0806dcd6cea/libcst-1.8.6-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:55ec021a296960c92e5a33b8d93e8ad4182b0eab657021f45262510a58223de1", size = 2188980, upload-time = "2025-11-03T22:33:05.152Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/14/c660204532407c5628e3b615015a902ed2d0b884b77714a6bdbe73350910/libcst-1.8.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ba9ab2b012fbd53b36cafd8f4440a6b60e7e487cd8b87428e57336b7f38409a4", size = 2074828, upload-time = "2025-11-03T22:33:06.864Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e2/c497c354943dff644749f177ee9737b09ed811b8fc842b05709a40fe0d1b/libcst-1.8.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c0a0cc80aebd8aa15609dd4d330611cbc05e9b4216bcaeabba7189f99ef07c28", size = 2225568, upload-time = "2025-11-03T22:33:08.354Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/45999676d07bd6d0eefa28109b4f97124db114e92f9e108de42ba46a8028/libcst-1.8.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:42a4f68121e2e9c29f49c97f6154e8527cd31021809cc4a941c7270aa64f41aa", size = 2286523, upload-time = "2025-11-03T22:33:10.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6c/517d8bf57d9f811862f4125358caaf8cd3320a01291b3af08f7b50719db4/libcst-1.8.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a434c521fadaf9680788b50d5c21f4048fa85ed19d7d70bd40549fbaeeecab1", size = 2288044, upload-time = "2025-11-03T22:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ce/24d7d49478ffb61207f229239879845da40a374965874f5ee60f96b02ddb/libcst-1.8.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6a65f844d813ab4ef351443badffa0ae358f98821561d19e18b3190f59e71996", size = 2392605, upload-time = "2025-11-03T22:33:12.962Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c3/829092ead738b71e96a4e96896c96f276976e5a8a58b4473ed813d7c962b/libcst-1.8.6-cp314-cp314t-win_amd64.whl", hash = "sha256:bdb14bc4d4d83a57062fed2c5da93ecb426ff65b0dc02ddf3481040f5f074a82", size = 2181581, upload-time = "2025-11-03T22:33:14.514Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6d/5d6a790a02eb0d9d36c4aed4f41b277497e6178900b2fa29c35353aa45ed/libcst-1.8.6-cp314-cp314t-win_arm64.whl", hash = "sha256:819c8081e2948635cab60c603e1bbdceccdfe19104a242530ad38a36222cb88f", size = 2065000, upload-time = "2025-11-03T22:33:16.257Z" },
+]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mutmut"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "coverage" },
+    { name = "libcst" },
+    { name = "pytest" },
+    { name = "setproctitle" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/b0/ebcae42b90b07756b7aa10c4176835f436332e6c1cb28bc35bae83462382/mutmut-3.6.0.tar.gz", hash = "sha256:bcbd3e4d0d2d4edf3dfb42955417279a8866a3dbbcb87d619f2f3fd0ac7fafda", size = 51538, upload-time = "2026-06-06T07:44:51.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/5a/a0caa3f9db407b5d12c311bd4c87aa67fdd6e3f329377149e303108a1c51/mutmut-3.6.0-py3-none-any.whl", hash = "sha256:a9f5b8dcf6cbf9496769d7cf8bdbba37a0ec709ad98f88d103238b62f10bdf37", size = 47770, upload-time = "2026-06-06T07:44:50.038Z" },
 ]
 
 [[package]]
@@ -166,6 +411,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -221,6 +475,99 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-ft"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/5a0d575de784f9a1f94e2b1288c6886f13f34185e13117ed530f32b6f8a8/pyyaml_ft-8.0.0.tar.gz", hash = "sha256:0c947dce03954c7b5d38869ed4878b2e6ff1d44b08a0d84dc83fdad205ae39ab", size = 141057, upload-time = "2025-06-10T15:32:15.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/ba/a067369fe61a2e57fb38732562927d5bae088c73cb9bb5438736a9555b29/pyyaml_ft-8.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8c1306282bc958bfda31237f900eb52c9bedf9b93a11f82e1aab004c9a5657a6", size = 187027, upload-time = "2025-06-10T15:31:48.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c5/a3d2020ce5ccfc6aede0d45bcb870298652ac0cf199f67714d250e0cdf39/pyyaml_ft-8.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30c5f1751625786c19de751e3130fc345ebcba6a86f6bddd6e1285342f4bbb69", size = 176146, upload-time = "2025-06-10T15:31:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bb/23a9739291086ca0d3189eac7cd92b4d00e9fdc77d722ab610c35f9a82ba/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa992481155ddda2e303fcc74c79c05eddcdbc907b888d3d9ce3ff3e2adcfb0", size = 746792, upload-time = "2025-06-10T15:31:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c2/e8825f4ff725b7e560d62a3609e31d735318068e1079539ebfde397ea03e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cec6c92b4207004b62dfad1f0be321c9f04725e0f271c16247d8b39c3bf3ea42", size = 786772, upload-time = "2025-06-10T15:31:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/35/be/58a4dcae8854f2fdca9b28d9495298fd5571a50d8430b1c3033ec95d2d0e/pyyaml_ft-8.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06237267dbcab70d4c0e9436d8f719f04a51123f0ca2694c00dd4b68c338e40b", size = 778723, upload-time = "2025-06-10T15:31:56.093Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ed/fed0da92b5d5d7340a082e3802d84c6dc9d5fa142954404c41a544c1cb92/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8a7f332bc565817644cdb38ffe4739e44c3e18c55793f75dddb87630f03fc254", size = 758478, upload-time = "2025-06-10T15:31:58.314Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/69/ac02afe286275980ecb2dcdc0156617389b7e0c0a3fcdedf155c67be2b80/pyyaml_ft-8.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7d10175a746be65f6feb86224df5d6bc5c049ebf52b89a88cf1cd78af5a367a8", size = 799159, upload-time = "2025-06-10T15:31:59.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/c492a9da2e39abdff4c3094ec54acac9747743f36428281fb186a03fab76/pyyaml_ft-8.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:58e1015098cf8d8aec82f360789c16283b88ca670fe4275ef6c48c5e30b22a96", size = 158779, upload-time = "2025-06-10T15:32:01.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/9b/41998df3298960d7c67653669f37710fa2d568a5fc933ea24a6df60acaf6/pyyaml_ft-8.0.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:e64fa5f3e2ceb790d50602b2fd4ec37abbd760a8c778e46354df647e7c5a4ebb", size = 191331, upload-time = "2025-06-10T15:32:02.602Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/16/2710c252ee04cbd74d9562ebba709e5a284faeb8ada88fcda548c9191b47/pyyaml_ft-8.0.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8d445bf6ea16bb93c37b42fdacfb2f94c8e92a79ba9e12768c96ecde867046d1", size = 182879, upload-time = "2025-06-10T15:32:04.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/40/ae8163519d937fa7bfa457b6f78439cc6831a7c2b170e4f612f7eda71815/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c56bb46b4fda34cbb92a9446a841da3982cdde6ea13de3fbd80db7eeeab8b49", size = 811277, upload-time = "2025-06-10T15:32:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/28d82dbff7f87b96f0eeac79b7d972a96b4980c1e445eb6a857ba91eda00/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dab0abb46eb1780da486f022dce034b952c8ae40753627b27a626d803926483b", size = 831650, upload-time = "2025-06-10T15:32:08.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/df/161c4566facac7d75a9e182295c223060373d4116dead9cc53a265de60b9/pyyaml_ft-8.0.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd48d639cab5ca50ad957b6dd632c7dd3ac02a1abe0e8196a3c24a52f5db3f7a", size = 815755, upload-time = "2025-06-10T15:32:09.435Z" },
+    { url = "https://files.pythonhosted.org/packages/05/10/f42c48fa5153204f42eaa945e8d1fd7c10d6296841dcb2447bf7da1be5c4/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:052561b89d5b2a8e1289f326d060e794c21fa068aa11255fe71d65baf18a632e", size = 810403, upload-time = "2025-06-10T15:32:11.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d2/e369064aa51009eb9245399fd8ad2c562bd0bcd392a00be44b2a824ded7c/pyyaml_ft-8.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3bb4b927929b0cb162fb1605392a321e3333e48ce616cdcfa04a839271373255", size = 835581, upload-time = "2025-06-10T15:32:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/28/26534bed77109632a956977f60d8519049f545abc39215d086e33a61f1f2/pyyaml_ft-8.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:de04cfe9439565e32f178106c51dd6ca61afaa2907d143835d501d84703d3793", size = 171579, upload-time = "2025-06-10T15:32:14.34Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -249,6 +596,99 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "setproctitle"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/48/49393a96a2eef1ab418b17475fb92b8fcfad83d099e678751b05472e69de/setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e", size = 27002, upload-time = "2025-09-05T12:51:25.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/cd/1b7ba5cad635510720ce19d7122154df96a2387d2a74217be552887c93e5/setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0", size = 18085, upload-time = "2025-09-05T12:49:22.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/b2da0a620490aae355f9d72072ac13e901a9fec809a6a24fc6493a8f3c35/setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4", size = 13097, upload-time = "2025-09-05T12:49:23.322Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2e/bd03ff02432a181c1787f6fc2a678f53b7dacdd5ded69c318fe1619556e8/setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f", size = 32191, upload-time = "2025-09-05T12:49:24.567Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/1e62fc0937a8549f2220445ed2175daacee9b6764c7963b16148119b016d/setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9", size = 33203, upload-time = "2025-09-05T12:49:25.871Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/3c/65edc65db3fa3df400cf13b05e9d41a3c77517b4839ce873aa6b4043184f/setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba", size = 34963, upload-time = "2025-09-05T12:49:27.044Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/89157e3de997973e306e44152522385f428e16f92f3cf113461489e1e2ee/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307", size = 32398, upload-time = "2025-09-05T12:49:28.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/18/77a765a339ddf046844cb4513353d8e9dcd8183da9cdba6e078713e6b0b2/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee", size = 33657, upload-time = "2025-09-05T12:49:30.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/63/f0b6205c64d74d2a24a58644a38ec77bdbaa6afc13747e75973bf8904932/setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1", size = 31836, upload-time = "2025-09-05T12:49:32.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e1277f9ba302f1a250bbd3eedbbee747a244b3cc682eb58fb9733968f6d8/setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d", size = 12556, upload-time = "2025-09-05T12:49:33.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7b/822a23f17e9003dfdee92cd72758441ca2a3680388da813a371b716fb07f/setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4", size = 13243, upload-time = "2025-09-05T12:49:34.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f0/2dc88e842077719d7384d86cc47403e5102810492b33680e7dadcee64cd8/setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e", size = 18049, upload-time = "2025-09-05T12:49:36.241Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b4/50940504466689cda65680c9e9a1e518e5750c10490639fa687489ac7013/setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798", size = 13079, upload-time = "2025-09-05T12:49:38.088Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/99/71630546b9395b095f4082be41165d1078204d1696c2d9baade3de3202d0/setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629", size = 32932, upload-time = "2025-09-05T12:49:39.271Z" },
+    { url = "https://files.pythonhosted.org/packages/50/22/cee06af4ffcfb0e8aba047bd44f5262e644199ae7527ae2c1f672b86495c/setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1", size = 33736, upload-time = "2025-09-05T12:49:40.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/a5949a8bb06ef5e7df214fc393bb2fb6aedf0479b17214e57750dfdd0f24/setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6", size = 35605, upload-time = "2025-09-05T12:49:42.362Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3a/50caca532a9343828e3bf5778c7a84d6c737a249b1796d50dd680290594d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c", size = 33143, upload-time = "2025-09-05T12:49:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/14/b843a251296ce55e2e17c017d6b9f11ce0d3d070e9265de4ecad948b913d/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a", size = 34434, upload-time = "2025-09-05T12:49:45.31Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b7/06145c238c0a6d2c4bc881f8be230bb9f36d2bf51aff7bddcb796d5eed67/setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739", size = 32795, upload-time = "2025-09-05T12:49:46.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/dc/ef76a81fac9bf27b84ed23df19c1f67391a753eed6e3c2254ebcb5133f56/setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f", size = 12552, upload-time = "2025-09-05T12:49:47.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5b/a9fe517912cd6e28cf43a212b80cb679ff179a91b623138a99796d7d18a0/setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300", size = 13247, upload-time = "2025-09-05T12:49:49.16Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/2f/fcedcade3b307a391b6e17c774c6261a7166aed641aee00ed2aad96c63ce/setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922", size = 18047, upload-time = "2025-09-05T12:49:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/afc141ca9631350d0a80b8f287aac79a76f26b6af28fd8bf92dae70dc2c5/setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee", size = 13073, upload-time = "2025-09-05T12:49:51.46Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ed/0a4f00315bc02510395b95eec3d4aa77c07192ee79f0baae77ea7b9603d8/setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd", size = 33284, upload-time = "2025-09-05T12:49:52.741Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e4/adf3c4c0a2173cb7920dc9df710bcc67e9bcdbf377e243b7a962dc31a51a/setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0", size = 34104, upload-time = "2025-09-05T12:49:54.416Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/6daf66394152756664257180439d37047aa9a1cfaa5e4f5ed35e93d1dc06/setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929", size = 35982, upload-time = "2025-09-05T12:49:56.295Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/62/f2c0595403cf915db031f346b0e3b2c0096050e90e0be658a64f44f4278a/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f", size = 33150, upload-time = "2025-09-05T12:49:58.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/29/10dd41cde849fb2f9b626c846b7ea30c99c81a18a5037a45cc4ba33c19a7/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698", size = 34463, upload-time = "2025-09-05T12:49:59.424Z" },
+    { url = "https://files.pythonhosted.org/packages/71/3c/cedd8eccfaf15fb73a2c20525b68c9477518917c9437737fa0fda91e378f/setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c", size = 32848, upload-time = "2025-09-05T12:50:01.107Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/0a0e27d1c9926fecccfd1f91796c244416c70bf6bca448d988638faea81d/setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd", size = 12544, upload-time = "2025-09-05T12:50:15.81Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1b/6bf4cb7acbbd5c846ede1c3f4d6b4ee52744d402e43546826da065ff2ab7/setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f", size = 13235, upload-time = "2025-09-05T12:50:16.89Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a4/d588d3497d4714750e3eaf269e9e8985449203d82b16b933c39bd3fc52a1/setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9", size = 18058, upload-time = "2025-09-05T12:50:02.501Z" },
+    { url = "https://files.pythonhosted.org/packages/05/77/7637f7682322a7244e07c373881c7e982567e2cb1dd2f31bd31481e45500/setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5", size = 13072, upload-time = "2025-09-05T12:50:03.601Z" },
+    { url = "https://files.pythonhosted.org/packages/52/09/f366eca0973cfbac1470068d1313fa3fe3de4a594683385204ec7f1c4101/setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29", size = 34490, upload-time = "2025-09-05T12:50:04.948Z" },
+    { url = "https://files.pythonhosted.org/packages/71/36/611fc2ed149fdea17c3677e1d0df30d8186eef9562acc248682b91312706/setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152", size = 35267, upload-time = "2025-09-05T12:50:06.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a4/64e77d0671446bd5a5554387b69e1efd915274686844bea733714c828813/setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c", size = 37376, upload-time = "2025-09-05T12:50:07.484Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/ad9c664fe524fb4a4b2d3663661a5c63453ce851736171e454fa2cdec35c/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b", size = 33963, upload-time = "2025-09-05T12:50:09.056Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a36de7caf2d90c4c28678da1466b47495cbbad43badb4e982d8db8167ed4/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18", size = 35550, upload-time = "2025-09-05T12:50:10.791Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/68/17e8aea0ed5ebc17fbf03ed2562bfab277c280e3625850c38d92a7b5fcd9/setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c", size = 33727, upload-time = "2025-09-05T12:50:12.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/33/90a3bf43fe3a2242b4618aa799c672270250b5780667898f30663fd94993/setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29", size = 12549, upload-time = "2025-09-05T12:50:13.074Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/50d1f07f3032e1f23d814ad6462bc0a138f369967c72494286b8a5228e40/setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9", size = 13243, upload-time = "2025-09-05T12:50:14.146Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c7/43ac3a98414f91d1b86a276bc2f799ad0b4b010e08497a95750d5bc42803/setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63", size = 18052, upload-time = "2025-09-05T12:50:17.928Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2c/dc258600a25e1a1f04948073826bebc55e18dbd99dc65a576277a82146fa/setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e", size = 13071, upload-time = "2025-09-05T12:50:19.061Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/8e3bb082992f19823d831f3d62a89409deb6092e72fc6940962983ffc94f/setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f", size = 33180, upload-time = "2025-09-05T12:50:20.395Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/af/ae692a20276d1159dd0cf77b0bcf92cbb954b965655eb4a69672099bb214/setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5", size = 34043, upload-time = "2025-09-05T12:50:22.454Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b2/6a092076324dd4dac1a6d38482bedebbff5cf34ef29f58585ec76e47bc9d/setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17", size = 35892, upload-time = "2025-09-05T12:50:23.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/8836b9f28cee32859ac36c3df85aa03e1ff4598d23ea17ca2e96b5845a8f/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e", size = 32898, upload-time = "2025-09-05T12:50:25.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/22/8fabdc24baf42defb599714799d8445fe3ae987ec425a26ec8e80ea38f8e/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0", size = 34308, upload-time = "2025-09-05T12:50:26.827Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/b9bee9de6c8cdcb3b3a6cb0b3e773afdb86bbbc1665a3bfa424a4294fda2/setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8", size = 32536, upload-time = "2025-09-05T12:50:28.5Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0c/75e5f2685a5e3eda0b39a8b158d6d8895d6daf3ba86dec9e3ba021510272/setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed", size = 12731, upload-time = "2025-09-05T12:50:43.955Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/acddbce90d1361e1786e1fb421bc25baeb0c22ef244ee5d0176511769ec8/setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416", size = 13464, upload-time = "2025-09-05T12:50:45.057Z" },
+    { url = "https://files.pythonhosted.org/packages/01/6d/20886c8ff2e6d85e3cabadab6aab9bb90acaf1a5cfcb04d633f8d61b2626/setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3", size = 18062, upload-time = "2025-09-05T12:50:29.78Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/26dfc5f198715f1343b95c2f7a1c16ae9ffa45bd89ffd45a60ed258d24ea/setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309", size = 13075, upload-time = "2025-09-05T12:50:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/21/9c/980b01f50d51345dd513047e3ba9e96468134b9181319093e61db1c47188/setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b", size = 34744, upload-time = "2025-09-05T12:50:32.777Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b4/82cd0c86e6d1c4538e1a7eb908c7517721513b801dff4ba3f98ef816a240/setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45", size = 35589, upload-time = "2025-09-05T12:50:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/9f6b2a7417fd45673037554021c888b31247f7594ff4bd2239918c5cd6d0/setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4", size = 37698, upload-time = "2025-09-05T12:50:35.524Z" },
+    { url = "https://files.pythonhosted.org/packages/20/92/927b7d4744aac214d149c892cb5fa6dc6f49cfa040cb2b0a844acd63dcaf/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1", size = 34201, upload-time = "2025-09-05T12:50:36.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/fd4901db5ba4b9d9013e62f61d9c18d52290497f956745cd3e91b0d80f90/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070", size = 35801, upload-time = "2025-09-05T12:50:38.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e3/54b496ac724e60e61cc3447f02690105901ca6d90da0377dffe49ff99fc7/setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73", size = 33958, upload-time = "2025-09-05T12:50:39.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a8/c84bb045ebf8c6fdc7f7532319e86f8380d14bbd3084e6348df56bdfe6fd/setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2", size = 12745, upload-time = "2025-09-05T12:50:41.377Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b6/3a5a4f9952972791a9114ac01dfc123f0df79903577a3e0a7a404a695586/setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a", size = 13469, upload-time = "2025-09-05T12:50:42.67Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/5b/5e1c117ac84e3cefcf8d7a7f6b2461795a87e20869da065a5c087149060b/setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1", size = 12587, upload-time = "2025-09-05T12:51:21.195Z" },
+    { url = "https://files.pythonhosted.org/packages/73/02/b9eadc226195dcfa90eed37afe56b5dd6fa2f0e5220ab8b7867b8862b926/setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65", size = 14286, upload-time = "2025-09-05T12:51:22.61Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/1be1d2a53c2a91ec48fa2ff4a409b395f836798adf194d99de9c059419ea/setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a", size = 13282, upload-time = "2025-09-05T12:51:24.094Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
 name = "teslaontarget"
 version = "1.1.0"
 source = { editable = "." }
@@ -260,7 +700,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "flake8" },
+    { name = "hypothesis" },
+    { name = "mutmut" },
     { name = "pytest" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -272,7 +715,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "flake8", specifier = ">=7.0.0" },
+    { name = "hypothesis", specifier = ">=6.0.0" },
+    { name = "mutmut", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
 ]
 
 [[package]]
@@ -287,6 +733,95 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/b0/5e44243a8e67971acb89fc1a8c4b16b126c3d55c3e69286d1ab50c20323c/teslapy-2.9.2.tar.gz", hash = "sha256:07961c170762e5565d780fb3e15485d4482dccd87ba0c7b9e34066fc1bb115cc", size = 67307, upload-time = "2026-06-15T19:29:03.915Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/e3/59b582fe889b22344fa70eb0e287ac0cc827c3875d5e8d60a257060033e3/teslapy-2.9.2-py2.py3-none-any.whl", hash = "sha256:8d347affbff08dfb01ecb2613c5cbac3233d288263fbcb40dab5927c72b44ad9", size = 44952, upload-time = "2026-06-15T19:28:59.046Z" },
+]
+
+[[package]]
+name = "textual"
+version = "8.2.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Raises the project to **100% line + branch coverage** with a meaningful, mutation-verified suite (built TDD-style over several iterations) — no metric-gaming.

## Coverage
```
TOTAL  895 stmts  212 branches  0 missed  =  100%   (220 tests)
```
Every module at 100%: utils, config_handler, cot, tak_client, health, tesla_api, cli, auth, __main__, __init__.

## Test quality (not just line-touching)
- **Mutation testing**: `scripts/mutation_check.py` — a deterministic harness (mutmut 3.x mis-routes imports in this uv/installed setup and falsely reports all-survived, so it's replaced by a working gate). **23/23 curated mutants killed** across core logic (operator swaps, comparison/guard inversions, constants, return values).
- **Property/fuzz tests** (hypothesis): geo-distance invariants (symmetry, non-negativity, bounds) and a generate-CoT "always-parseable-XML + lat/lon round-trip" property.
- **Integration tests** at real boundaries: sockets (tak_client), files/threads (health), teslapy/argparse/signal/threads (cli, auth, tesla_api) — all mocked.

## Bugs found & fixed (with regression tests)
- **cot._security_remark TypeError** on `None` window/trunk fields (Tesla returns null; `None > 0` crashed mid-packet and dropped the send) → guarded with `(data.get(k) or 0) > 0`.
- **Flaky stale-bytecode** in the mutation harness (mutate→import→revert within one mtime tick reused mutated `.pyc`) → `PYTHONDONTWRITEBYTECODE=1`.

## Complexity reductions (mccabe, all now <=10)
- `cot.generate_cot_packet` 27 → helpers (`_build_remarks`/`_charging_remark`/…)
- `tesla_api.fetch_and_send_data_for_vehicle` **37** → 10 helpers (`_seed_initial_position`, `_classify_api_error`, `_handle_api_error`, `_poll_once`, …); the thin infinite supervisor loop is the only `# pragma: no cover` (justified).
- `cli.main` 18 → phase helpers; `config_handler.load_from_file` 11 → `_resolve_config_path`.

## Exclusions (justified)
- `__main__.py` `if __name__=='__main__'` block and `fetch_and_send`'s infinite `while True` supervisor wrapper — environment-driven loops with no return; their bodies are fully tested via extracted helpers.

## Tooling
Adds pytest-cov, hypothesis, mutmut to the dev group; branch-coverage config; all refactors behavior-preserving (verified green at each step).

Built on #25 (TLS fix) and #26 (uv modernization).
