### PR TITLE
ci: consolidated Trivy security scanning (closes #11, #13–#16)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,74 @@
+name: security
+
+# Consolidated Trivy security scanning (closes the secret/dep/image/IaC issues
+# in one workflow rather than four). Runs on PRs (catch before merge), on main,
+# and weekly to catch newly-disclosed CVEs in unchanged dependencies.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ['**']
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+  security-events: write  # upload SARIF to the Security tab (public repo: free)
+
+jobs:
+  secrets:
+    name: Secret scan (blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Trivy secret scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: secret
+          exit-code: '1'  # a committed secret must fail the build
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+
+  deps-and-config:
+    name: Dependency + IaC scan (report)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Trivy filesystem scan (vuln + misconfig)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          scanners: vuln,misconfig
+          format: sarif
+          output: trivy-fs.sarif
+          exit-code: '0'  # report; don't block merges on unfixable base CVEs
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  image:
+    name: Container image scan (report)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build image
+        run: docker build -t teslaontarget:scan .
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: image
+          image-ref: teslaontarget:scan
+          format: sarif
+          output: trivy-image.sarif
+          exit-code: '0'
+      - name: Upload results to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD:/repo" "$TRIVY_IMAGE" \
             config --format sarif --output /repo/trivy-config.sarif \
-            --exit-code 0 --no-progress /repo
+            --exit-code 0 /repo
       - name: Upload results to Security tab
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,8 @@
 name: security
 
-# Consolidated Trivy security scanning (closes the secret/dep/image/IaC issues
-# in one workflow rather than four). Runs on PRs (catch before merge), on main,
-# and weekly to catch newly-disclosed CVEs in unchanged dependencies.
+# Consolidated Trivy scanning: secrets (blocking), dependency CVEs, container
+# image CVEs, and IaC/Dockerfile misconfiguration. Runs on PRs, on main, and
+# weekly to catch newly-disclosed CVEs in unchanged dependencies.
 on:
   push:
     branches: [main]
@@ -30,29 +30,51 @@ jobs:
           exit-code: '1'  # a committed secret must fail the build
           severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
 
-  deps-and-config:
-    name: Dependency + IaC scan (report)
+  vulnerabilities:
+    name: Dependency CVEs (report)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Trivy filesystem scan (vuln + misconfig)
+      - name: Trivy filesystem vuln scan
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: fs
           scan-ref: .
-          scanners: vuln,misconfig
+          scanners: vuln
           format: sarif
-          output: trivy-fs.sarif
+          output: trivy-deps.sarif
           exit-code: '0'  # report; don't block merges on unfixable base CVEs
       - name: Upload results to Security tab
+        # Forked-PR tokens lack security-events:write, so only upload for pushes,
+        # schedules, and same-repo PRs (the scan itself still runs on forks).
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
         with:
-          sarif_file: trivy-fs.sarif
-          category: trivy-fs
+          sarif_file: trivy-deps.sarif
+          category: trivy-deps
+
+  config:
+    name: IaC / Dockerfile misconfig (report)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Trivy config scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          exit-code: '0'
+      - name: Upload results to Security tab
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
 
   image:
-    name: Container image scan (report)
+    name: Container image CVEs (report)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -67,8 +89,8 @@ jobs:
           output: trivy-image.sarif
           exit-code: '0'
       - name: Upload results to Security tab
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Trivy secret scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           scan-type: fs
           scan-ref: .
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Trivy filesystem vuln scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           scan-type: fs
           scan-ref: .
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           scan-type: config
           scan-ref: .
@@ -81,7 +81,7 @@ jobs:
       - name: Build image
         run: docker build -t teslaontarget:scan .
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.33.1
         with:
           scan-type: image
           image-ref: teslaontarget:scan

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,9 @@ name: security
 # Consolidated Trivy scanning: secrets (blocking), dependency CVEs, container
 # image CVEs, and IaC/Dockerfile misconfiguration. Runs on PRs, on main, and
 # weekly to catch newly-disclosed CVEs in unchanged dependencies.
+#
+# Trivy is run from its official image (pinned) rather than trivy-action, whose
+# binary-installer step is unreliable on hosted runners.
 on:
   push:
     branches: [main]
@@ -15,6 +18,9 @@ permissions:
   contents: read
   security-events: write  # upload SARIF to the Security tab (public repo: free)
 
+env:
+  TRIVY_IMAGE: aquasec/trivy:0.65.0
+
 jobs:
   secrets:
     name: Secret scan (blocking)
@@ -22,28 +28,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Trivy secret scan
-        uses: aquasecurity/trivy-action@v0.33.1
-        with:
-          scan-type: fs
-          scan-ref: .
-          scanners: secret
-          exit-code: '1'  # a committed secret must fail the build
-          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        run: |
+          docker run --rm -v "$PWD:/repo" "$TRIVY_IMAGE" \
+            fs --scanners secret --exit-code 1 --no-progress /repo
 
   vulnerabilities:
     name: Dependency CVEs (report)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Trivy filesystem vuln scan
-        uses: aquasecurity/trivy-action@v0.33.1
-        with:
-          scan-type: fs
-          scan-ref: .
-          scanners: vuln
-          format: sarif
-          output: trivy-deps.sarif
-          exit-code: '0'  # report; don't block merges on unfixable base CVEs
+      - name: Trivy dependency scan
+        run: |
+          docker run --rm -v "$PWD:/repo" "$TRIVY_IMAGE" \
+            fs --scanners vuln --format sarif --output /repo/trivy-deps.sarif \
+            --exit-code 0 --no-progress /repo
       - name: Upload results to Security tab
         # Forked-PR tokens lack security-events:write, so only upload for pushes,
         # schedules, and same-repo PRs (the scan itself still runs on forks).
@@ -59,13 +57,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Trivy config scan
-        uses: aquasecurity/trivy-action@v0.33.1
-        with:
-          scan-type: config
-          scan-ref: .
-          format: sarif
-          output: trivy-config.sarif
-          exit-code: '0'
+        run: |
+          docker run --rm -v "$PWD:/repo" "$TRIVY_IMAGE" \
+            config --format sarif --output /repo/trivy-config.sarif \
+            --exit-code 0 --no-progress /repo
       - name: Upload results to Security tab
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v3
@@ -81,13 +76,10 @@ jobs:
       - name: Build image
         run: docker build -t teslaontarget:scan .
       - name: Trivy image scan
-        uses: aquasecurity/trivy-action@v0.33.1
-        with:
-          scan-type: image
-          image-ref: teslaontarget:scan
-          format: sarif
-          output: trivy-image.sarif
-          exit-code: '0'
+        run: |
+          docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v "$PWD:/out" "$TRIVY_IMAGE" \
+            image --format sarif --output /out/trivy-image.sarif \
+            --exit-code 0 --no-progress teslaontarget:scan
       - name: Upload results to Security tab
         if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Collapses the five Trivy issues into **one workflow** (they were the same effort over-split into corporate-style tickets):

| Scan | Issue | Behavior |
|------|-------|----------|
| Secrets (fs) | #13 | **blocking** — a committed credential fails the build |
| Python deps (fs vuln) | #15 | report → Security tab (SARIF) |
| IaC / Dockerfile / workflows (fs misconfig) | #16 | report → Security tab |
| Container image | #14 | report → Security tab |
| Umbrella | #11 | — |

Runs on PRs, main, and weekly (catches newly-disclosed CVEs in unchanged deps). Vuln/config are **report-only** so unfixable base-image CVEs don't block every merge; **secrets block**. Appropriately sized for a one-container homelab app.

Closes #11, #13, #14, #15, #16.