### PR TITLE
docs: refresh README for current state (versions, new modules, alerting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # TeslaOnTarget
 
 Bridge your Tesla vehicle with TAK (Team Awareness Kit) servers for real-time position tracking.
@@ -6,382 +5,78 @@ Bridge your Tesla vehicle with TAK (Team Awareness Kit) servers for real-time po
 ![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![TAK](https://img.shields.io/badge/TAK-Compatible-orange.svg)
-![Tesla](https://img.shields.io/badge/Tesla-API-red.svg)
 [![CI](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/ci-cd.yml)
 [![Security](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/security.yml/badge.svg)](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/security.yml)
-![Docker](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/docker-publish.yml/badge.svg)
 [![Release](https://img.shields.io/github/v/release/joshuafuller/TeslaOnTarget)](https://github.com/joshuafuller/TeslaOnTarget/releases)
-![GitHub Container Registry](https://img.shields.io/badge/ghcr.io-ready-brightgreen)
+![GHCR](https://img.shields.io/badge/ghcr.io-ready-brightgreen)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuafuller/TeslaOnTarget)
 
-## What is TeslaOnTarget?
-
-TeslaOnTarget is a lightweight Python application that connects your Tesla vehicle to a TAK (Team Awareness Kit) server, enabling real-time vehicle tracking in tactical awareness applications. It bridges the gap between Tesla's modern API and military/emergency response systems that use Cursor on Target (CoT) messaging.
-
-### Use Cases
-- **Emergency Response** - Track response vehicles in real-time
-- **Fleet Management** - Monitor multiple Tesla vehicles on a single TAK display
-- **Personal Tracking** - Keep tabs on your vehicle's location and status
-- **Integration Testing** - Test TAK systems with real vehicle data
+TeslaOnTarget connects your Tesla to a TAK server and streams live position and status as Cursor-on-Target (CoT) messages — for emergency response, fleet or personal tracking, or testing TAK systems with real vehicle data.
 
 ## Features
 
-- **Real-time Vehicle Tracking** - GPS position updates every 10 seconds
-- **Battery & Charging Status** - Monitor charge level and time to completion
-- **Smart Wake Management** - Wakes vehicle only once, preserves battery when parked
-- **Multi-TAK Compatible** - Tested with iTAK, ATAK, and WebTAK
-- **Security Alerts** - Warnings for open windows/doors when parked
-- **Dead Reckoning** - Smooth 1Hz position updates between 10-second API polls
-- **Resilient Connection** - Fail-fast sends with automatic background reconnection
-- **Self-Healing Health Monitor** - Detects stalled TAK sends, forces reconnect, and restarts for recovery
-- **Failure Alerting** - Optional webhook/ntfy push when sends stall or a restart is needed (opt-in)
-- **Detailed Logging** - Comprehensive logs for troubleshooting
-- **Secure Token Storage** - OAuth2 token management via TeslaPy
-- **Location Caching** - Continues reporting last position when vehicle sleeps
+- **Real-time tracking** — GPS updates every 10s with 1Hz dead-reckoning in between
+- **Rich status** — battery, charging, and parked-security (doors/windows/sentry) in the CoT remarks
+- **Multi-vehicle** — track your whole account from one instance (iTAK / ATAK / WebTAK)
+- **Self-healing** — health monitor reconnects on stalled sends and restarts for recovery
+- **Failure alerting** — optional webhook/ntfy push when sends stall (opt-in)
+- **Battery-friendly** — wakes the vehicle once, reports last position while it sleeps
+
+## Quick start (Docker)
+
+```bash
+docker pull ghcr.io/joshuafuller/teslaontarget:latest   # or :1.2.0 to pin a release
+
+cp .env.example .env          # set TAK_SERVER and TESLA_USERNAME
+
+# one-time Tesla login
+docker run -it --env-file .env -v tesla_data:/data ghcr.io/joshuafuller/teslaontarget auth
+
+# start tracking
+docker run -d --env-file .env -v tesla_data:/data -v tesla_logs:/logs \
+  --name teslaontarget --restart unless-stopped ghcr.io/joshuafuller/teslaontarget
+```
+
+Prefer a non-Docker install? `uv sync`, then `cp config.py.template config.py` and `python -m teslaontarget.auth`. Full guides below.
 
 ## Requirements
 
-- **Python 3.11+** 
-- **Tesla Account** with a vehicle
-- **TAK Server** (one of the following):
-  - [OpenTAKServer](https://github.com/brian7704/OpenTAKServer)
-  - TAK Server (Official)
-  - Any CoT-compatible server
-- **Network Access** to both internet (Tesla API) and your TAK server
+- **Python 3.11+** (bundled in the Docker image)
+- A **Tesla account** with a vehicle
+- A **CoT-capable TAK server** reachable over plaintext TCP
 
-### ⚠️ Important Security Note
-**This version only supports plaintext TCP connections to TAK servers.** SSL/TLS/QUIC support is planned for a future release. For security:
-- Run TeslaOnTarget on the same network as your TAK server
-- Ideally run it directly on the TAK server machine
-- Do NOT expose across WAN/Internet connections
-- Use VPN if remote access is required
+## ⚠️ Security
 
-## Quick Start
+Only **plaintext TCP** to the TAK server is supported (no TLS yet). Keep TeslaOnTarget on the same LAN as your TAK server (ideally on the TAK host) or behind a VPN — do not expose it across the internet.
 
-### Option 1: Docker (Recommended)
+## Configuration
 
-#### Using Pre-built Image (Easiest)
-```bash
-# Pull the latest image
-docker pull ghcr.io/joshuafuller/teslaontarget:latest
-# ...or pin a specific release (see Releases / CHANGELOG.md):
-# docker pull ghcr.io/joshuafuller/teslaontarget:1.2.0
-
-# Create configuration
-wget https://raw.githubusercontent.com/joshuafuller/TeslaOnTarget/main/.env.example
-cp .env.example .env
-# Edit .env with your TAK server IP and Tesla email
-
-# Authenticate with Tesla
-docker run -it --env-file .env -v tesla_data:/data ghcr.io/joshuafuller/teslaontarget auth
-
-# Or minimal auth command (TAK_SERVER not required for auth):
-# docker run -it -e TESLA_USERNAME=your@email.com -v tesla_data:/data ghcr.io/joshuafuller/teslaontarget auth
-
-# Run TeslaOnTarget
-docker run -d --env-file .env -v tesla_data:/data -v tesla_logs:/logs \
-  --name teslaontarget --restart unless-stopped \
-  ghcr.io/joshuafuller/teslaontarget
-```
-
-#### Building from Source
-```bash
-# Clone repository
-git clone https://github.com/joshuafuller/TeslaOnTarget.git
-cd TeslaOnTarget
-
-# Setup configuration
-cp .env.example .env
-# Edit .env with your TAK server IP and Tesla email
-
-# Build Docker image
-./docker-run.sh build
-
-# Authenticate with Tesla (one-time)
-./docker-run.sh auth
-
-# Start tracking
-./docker-run.sh start
-
-# View logs
-./docker-run.sh logs
-```
-
-See [docs/DOCKER.md](docs/DOCKER.md) for detailed Docker instructions and [docs/AUTHENTICATION.md](docs/AUTHENTICATION.md) for Tesla login help.
-
-### Option 2: Traditional Installation
-
-#### 1. Clone & Install
-
-```bash
-git clone https://github.com/joshuafuller/TeslaOnTarget.git
-cd TeslaOnTarget
-uv sync   # install uv first: https://docs.astral.sh/uv/getting-started/installation/
-```
-
-#### 2. Configure
-
-Copy the template and edit with your settings:
-```bash
-cp config.py.template config.py
-nano config.py
-```
-
-Required settings:
-```python
-COT_URL = "tcp://192.168.1.100:8085"  # Your TAK server
-TESLA_USERNAME = "your@email.com"      # Your Tesla account email
-```
-
-#### 3. Authenticate with Tesla
-
-```bash
-python3 -m teslaontarget.auth
-```
-
-This will:
-1. Open Tesla's login page in your browser
-2. After login, you'll land on a "Page Not Found" error (this is normal!)
-3. Copy the ENTIRE URL from your browser's address bar
-4. Paste it back in the terminal when prompted
-
-#### 4. Start Tracking
-
-```bash
-./teslaontarget.sh start
-```
-
-View live logs:
-```bash
-./teslaontarget.sh logs
-```
-
-## Configuration Options
+Set via environment variables (Docker) or `config.py` (source). The essentials:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `COT_URL` | TAK server URL (tcp://host:port) | `tcp://YOUR_TAK_SERVER:8085` |
-| `API_LOOP_DELAY` | Seconds between Tesla API calls | `10` |
-| `TESLA_USERNAME` | Your Tesla account email | Required |
-| `LAST_POSITION_FILE` | Cache file for position data | `last_known_position.json` |
-| `DEBUG_MODE` | Save all Tesla API responses for analysis | `False` |
-| `DEAD_RECKONING_ENABLED` | Interpolate position between API updates for smooth tracking | `True` |
-| `DEAD_RECKONING_DELAY` | Seconds between interpolated position updates (1 = 1Hz) | `1` |
-| `ALERT_WEBHOOK_URL` | Optional ntfy topic / webhook for failure alerts (empty = disabled) | _(empty)_ |
-| `HEALTH_NO_SEND_SECONDS` | Stall threshold before forcing a reconnect (0 = auto) | `0` |
-| `HEALTH_HARD_RESTART_SECONDS` | No-send threshold before exiting for a supervisor restart (0 = auto) | `0` |
+| `TAK_SERVER` / `COT_URL` | TAK server host (or full `tcp://host:port`) | required |
+| `TESLA_USERNAME` | Tesla account email | required |
+| `ALERT_WEBHOOK_URL` | ntfy topic / webhook for failure alerts | _(off)_ |
 
-## 📡 TAK Server Setup
+Full reference (all options, multi-vehicle filtering, debug capture, what's transmitted): **[docs/CONFIGURATION.md](docs/CONFIGURATION.md)**.
 
-### FreeTAK Server
-Default configuration should work. Ensure TCP port 8085 is open.
+## Documentation
 
-### TAK Server
-Configure a TCP input on port 8085 (or your chosen port).
+- **[Documentation index](docs/README.md)** — start here
+- [Docker guide](docs/DOCKER.md) · [Tesla authentication](docs/AUTHENTICATION.md) · [Configuration & operations](docs/CONFIGURATION.md) · [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [CHANGELOG](CHANGELOG.md) · [Releases](https://github.com/joshuafuller/TeslaOnTarget/releases) · [Roadmap](docs/ROADMAP.md) · [Contributing](CONTRIBUTING.md)
 
-### Network Requirements
-- Firewall must allow TCP connections to TAK server (plaintext only in v1.0)
-- No authentication required (or configure as needed)
-- TAK clients must be on same network or have routing to server
-- **Security**: Keep TAK traffic on local network only due to plaintext limitation
+## Known limitations
 
-## Management Commands
+- No SSL/TLS — plaintext TCP only (planned; see the roadmap)
+- Wakes the vehicle once on startup only (by design, to preserve battery)
+- No authentication to the TAK server — relies on network security
 
-Single control script for all operations:
+## License
 
-```bash
-./teslaontarget.sh start     # Start tracking in background
-./teslaontarget.sh stop      # Stop tracking
-./teslaontarget.sh restart   # Restart tracking
-./teslaontarget.sh status    # Check if running
-./teslaontarget.sh logs      # View live logs
-./teslaontarget.sh help      # Show all commands
-```
-
-For Tesla authentication:
-```bash
-python3 -m teslaontarget.auth  # Set up or refresh Tesla authentication
-```
-
-## Verifying Installation
-
-After starting TeslaOnTarget, verify it's working:
-
-1. **Check logs**: `./docker-run.sh logs` (Docker) or `./teslaontarget.sh logs` (Traditional)
-   - Should show "Connected to TAK server"
-   - Should show "Successfully sent CoT packet"
-
-2. **Check TAK client**:
-   - Open iTAK/ATAK/WebTAK
-   - Look for your vehicle on the map
-   - Verify updates every 10 seconds
-
-3. **Check status**: `./docker-run.sh status`
-   - Should show "TeslaOnTarget is running"
-
-## Troubleshooting
-
-### Vehicle Not Appearing in TAK
-1. Check TAK server connectivity: `telnet your-tak-server 8085`
-2. Verify vehicle is online in Tesla app
-3. Check logs: `./teslaontarget.sh logs`
-4. Ensure TAK client is connected to same server
-
-### Authentication Issues
-```bash
-rm cache.json
-python3 -m teslaontarget.auth
-```
-
-### Vehicle Shows Wrong Location
-- Vehicle may be in parking garage (no GPS)
-- Wait 10 seconds for next update
-- Check if vehicle is actually at shown location
-
-### High Tesla Battery Drain
-- Normal: Vehicle is woken once on startup only
-- Abnormal: Check logs for repeated wake attempts
-- Solution: Restart the service
-
-## 📁 Project Structure
-
-```
-TeslaOnTarget/
-├── teslaontarget/        # Main package directory
-│   ├── __init__.py       # Package initialization
-│   ├── __main__.py       # Entry point
-│   ├── cli.py            # CLI / startup, per-vehicle tracking threads
-│   ├── tesla_api.py      # Tesla API integration + dead reckoning
-│   ├── vehicle_mapper.py # Tesla payload -> CoT data mapping (pure)
-│   ├── cot.py            # CoT message generation
-│   ├── config_handler.py # Immutable AppConfig + loader
-│   ├── tak_client.py     # TAK server connection
-│   ├── health.py         # Health monitor + failure alerting
-│   ├── constants.py      # Shared physical constants
-│   ├── utils.py          # Helper functions
-│   └── auth.py           # Tesla authentication
-├── teslaontarget.sh     # Single control script (start/stop/status)
-├── config.py            # Your configuration (don't commit!)
-├── pyproject.toml       # Project metadata & dependencies (uv)
-├── uv.lock              # Pinned dependency lockfile
-├── docs/                # Detailed documentation
-│   ├── README.md        # Full documentation
-│   └── tesla_api_reference.md  # Tesla API details
-└── tests/               # Unit tests
-```
-
-## Security Considerations
-
-- **Never commit** `config.py` or `cache.json` to version control
-- **Plaintext Only**: v1.0 uses unencrypted TCP - keep on local network only
-- Run TeslaOnTarget on same machine or network as TAK server
-- Keep your TAK server behind a firewall or VPN
-- Use network segmentation for TAK infrastructure
-- Rotate Tesla tokens periodically (automatic via TeslaPy)
-- Monitor `teslaontarget.log` for suspicious activity
-
-## Multi-Vehicle Support
-
-TeslaOnTarget supports tracking multiple vehicles from a single instance. By default, it will track all vehicles on your Tesla account. You can also configure it to track specific vehicles:
-
-```python
-# In config.py - Track all vehicles (default)
-VEHICLE_FILTER = []
-
-# Track specific vehicles by display name
-VEHICLE_FILTER = ["Model Y", "Cybertruck"]
-
-# Track specific vehicles by VIN
-VEHICLE_FILTER = ["5YJ3E1EA8NF000000", "5YJ3E1EA8NF000001"]
-
-# Mix display names and VINs
-VEHICLE_FILTER = ["Model Y", "5YJ3E1EA8NF000001"]
-```
-
-Each vehicle:
-- Gets its own unique identifier in TAK
-- Has separate position caching (last_position_VIN.json)
-- Runs in its own thread for independent tracking
-- Shares a single TAK server connection
-
-## Known Limitations
-
-- **No SSL/TLS support** - plaintext TCP only (SSL planned for v2.0)
-- Updates only when vehicle is awake or every 10 seconds when asleep (last position)
-- Cannot wake vehicle remotely after initial startup (by design)
-- No authentication to TAK server (depends on network security)
-
-## 📊 Data Transmitted
-
-TeslaOnTarget sends the following in each CoT message:
-- GPS Position (latitude/longitude)
-- Heading (0-360 degrees)
-- Speed (when moving)
-- Battery level (percentage)
-- Charging state
-- Vehicle name as callsign
-
-## Roadmap
-
-See [docs/ROADMAP.md](docs/ROADMAP.md) for planned features, including SSL/TLS support in v2.0.
-
-## Contributing
-
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
-## 📜 License
-
-MIT License - see [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- [TeslaPy](https://github.com/tdorssers/TeslaPy) - Tesla API Python implementation
-- Tesla owners community for API documentation
-
-## Disclaimer
-
-This project is not affiliated with Tesla, Inc. Use at your own risk. Be mindful of:
-- Tesla API rate limits
-- Vehicle battery consumption
-- Local laws regarding vehicle tracking
-
-## 🐛 Debug Mode & Data Analysis
-
-When `DEBUG_MODE = True` in your config.py, all Tesla API responses are saved to the `tesla_api_captures/` directory. This is useful for:
-
-- Debugging issues with speed, vehicle state detection, etc.
-- Analyzing Tesla API responses
-- Replaying drive data for development
-
-### Analyzing Captured Data
-
-Two analysis tools are available:
-
-1. **Quick replay tool** - Shows extracted data:
-```bash
-python3 tools/replay_captures.py
-```
-
-2. **Full analysis tool** - Analyzes complete API responses:
-```bash
-python3 tools/analyze_full_captures.py
-```
-
-The full analysis tool will:
-- List ALL available fields in the Tesla API
-- Find all vehicle state related fields
-- Show fields that change between captures
-- Provide detailed state analysis
-
-Perfect for discovering new fields and debugging issues!
-
-## 📞 Support
-
-- **Issues**: [GitHub Issues](https://github.com/joshuafuller/TeslaOnTarget/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/joshuafuller/TeslaOnTarget/discussions)
-- **Documentation**: See [docs/](docs/) directory
+MIT — see [LICENSE](LICENSE). Not affiliated with Tesla, Inc. Use responsibly: mind Tesla API rate limits, battery consumption, and local laws on vehicle tracking.
 
 ---
 
 Made with ❤️ for the TAK community
-

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker run -d --env-file .env -v tesla_data:/data -v tesla_logs:/logs \
   --name teslaontarget --restart unless-stopped ghcr.io/joshuafuller/teslaontarget
 ```
 
-Prefer a non-Docker install? `uv sync`, copy `config.py.template` → `config.py`, run `python -m teslaontarget.auth`, then `./teslaontarget.sh start`. Full guides below.
+Prefer a non-Docker install? `uv sync`, copy `config.py.template` → `config.py`, run `uv run python -m teslaontarget.auth`, then `./teslaontarget.sh start`. Full guides below.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,14 @@
 
 Bridge your Tesla vehicle with TAK (Team Awareness Kit) servers for real-time position tracking.
 
-![Python](https://img.shields.io/badge/python-3.7+-blue.svg)
+![Python](https://img.shields.io/badge/python-3.11+-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![TAK](https://img.shields.io/badge/TAK-Compatible-orange.svg)
 ![Tesla](https://img.shields.io/badge/Tesla-API-red.svg)
+[![CI](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/ci-cd.yml)
+[![Security](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/security.yml/badge.svg)](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/security.yml)
 ![Docker](https://github.com/joshuafuller/TeslaOnTarget/actions/workflows/docker-publish.yml/badge.svg)
+[![Release](https://img.shields.io/github/v/release/joshuafuller/TeslaOnTarget)](https://github.com/joshuafuller/TeslaOnTarget/releases)
 ![GitHub Container Registry](https://img.shields.io/badge/ghcr.io-ready-brightgreen)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuafuller/TeslaOnTarget)
 
@@ -29,14 +32,16 @@ TeslaOnTarget is a lightweight Python application that connects your Tesla vehic
 - **Multi-TAK Compatible** - Tested with iTAK, ATAK, and WebTAK
 - **Security Alerts** - Warnings for open windows/doors when parked
 - **Dead Reckoning** - Smooth 1Hz position updates between 10-second API polls
-- **Resilient Connection** - Automatic reconnection and error recovery
+- **Resilient Connection** - Fail-fast sends with automatic background reconnection
+- **Self-Healing Health Monitor** - Detects stalled TAK sends, forces reconnect, and restarts for recovery
+- **Failure Alerting** - Optional webhook/ntfy push when sends stall or a restart is needed (opt-in)
 - **Detailed Logging** - Comprehensive logs for troubleshooting
 - **Secure Token Storage** - OAuth2 token management via TeslaPy
 - **Location Caching** - Continues reporting last position when vehicle sleeps
 
 ## Requirements
 
-- **Python 3.7+** 
+- **Python 3.11+** 
 - **Tesla Account** with a vehicle
 - **TAK Server** (one of the following):
   - [OpenTAKServer](https://github.com/brian7704/OpenTAKServer)
@@ -59,6 +64,8 @@ TeslaOnTarget is a lightweight Python application that connects your Tesla vehic
 ```bash
 # Pull the latest image
 docker pull ghcr.io/joshuafuller/teslaontarget:latest
+# ...or pin a specific release (see Releases / CHANGELOG.md):
+# docker pull ghcr.io/joshuafuller/teslaontarget:1.2.0
 
 # Create configuration
 wget https://raw.githubusercontent.com/joshuafuller/TeslaOnTarget/main/.env.example
@@ -160,6 +167,9 @@ View live logs:
 | `DEBUG_MODE` | Save all Tesla API responses for analysis | `False` |
 | `DEAD_RECKONING_ENABLED` | Interpolate position between API updates for smooth tracking | `True` |
 | `DEAD_RECKONING_DELAY` | Seconds between interpolated position updates (1 = 1Hz) | `1` |
+| `ALERT_WEBHOOK_URL` | Optional ntfy topic / webhook for failure alerts (empty = disabled) | `` (off) |
+| `HEALTH_NO_SEND_SECONDS` | Stall threshold before forcing a reconnect (0 = auto) | `0` |
+| `HEALTH_HARD_RESTART_SECONDS` | No-send threshold before exiting for a supervisor restart (0 = auto) | `0` |
 
 ## 📡 TAK Server Setup
 
@@ -240,10 +250,14 @@ TeslaOnTarget/
 ├── teslaontarget/        # Main package directory
 │   ├── __init__.py      # Package initialization
 │   ├── __main__.py      # Entry point
-│   ├── tesla_api.py     # Tesla API integration
+│   ├── cli.py           # CLI / startup, per-vehicle tracking threads
+│   ├── tesla_api.py     # Tesla API integration + dead reckoning
+│   ├── vehicle_mapper.py # Tesla payload -> CoT data mapping (pure)
 │   ├── cot.py           # CoT message generation
-│   ├── config_handler.py # Configuration management
+│   ├── config_handler.py # Immutable AppConfig + loader
 │   ├── tak_client.py    # TAK server connection
+│   ├── health.py        # Health monitor + failure alerting
+│   ├── constants.py     # Shared physical constants
 │   ├── utils.py         # Helper functions
 │   └── auth.py          # Tesla authentication
 ├── teslaontarget.sh     # Single control script (start/stop/status)
@@ -363,8 +377,8 @@ Perfect for discovering new fields and debugging issues!
 
 ## 📞 Support
 
-- **Issues**: [GitHub Issues](https://github.com/yourusername/TeslaOnTarget/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/yourusername/TeslaOnTarget/discussions)
+- **Issues**: [GitHub Issues](https://github.com/joshuafuller/TeslaOnTarget/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/joshuafuller/TeslaOnTarget/discussions)
 - **Documentation**: See [docs/](docs/) directory
 
 ---

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ View live logs:
 | `DEBUG_MODE` | Save all Tesla API responses for analysis | `False` |
 | `DEAD_RECKONING_ENABLED` | Interpolate position between API updates for smooth tracking | `True` |
 | `DEAD_RECKONING_DELAY` | Seconds between interpolated position updates (1 = 1Hz) | `1` |
-| `ALERT_WEBHOOK_URL` | Optional ntfy topic / webhook for failure alerts (empty = disabled) | `` (off) |
+| `ALERT_WEBHOOK_URL` | Optional ntfy topic / webhook for failure alerts (empty = disabled) | _(empty)_ |
 | `HEALTH_NO_SEND_SECONDS` | Stall threshold before forcing a reconnect (0 = auto) | `0` |
 | `HEALTH_HARD_RESTART_SECONDS` | No-send threshold before exiting for a supervisor restart (0 = auto) | `0` |
 
@@ -248,18 +248,18 @@ python3 -m teslaontarget.auth
 ```
 TeslaOnTarget/
 ├── teslaontarget/        # Main package directory
-│   ├── __init__.py      # Package initialization
-│   ├── __main__.py      # Entry point
-│   ├── cli.py           # CLI / startup, per-vehicle tracking threads
-│   ├── tesla_api.py     # Tesla API integration + dead reckoning
+│   ├── __init__.py       # Package initialization
+│   ├── __main__.py       # Entry point
+│   ├── cli.py            # CLI / startup, per-vehicle tracking threads
+│   ├── tesla_api.py      # Tesla API integration + dead reckoning
 │   ├── vehicle_mapper.py # Tesla payload -> CoT data mapping (pure)
-│   ├── cot.py           # CoT message generation
+│   ├── cot.py            # CoT message generation
 │   ├── config_handler.py # Immutable AppConfig + loader
-│   ├── tak_client.py    # TAK server connection
-│   ├── health.py        # Health monitor + failure alerting
-│   ├── constants.py     # Shared physical constants
-│   ├── utils.py         # Helper functions
-│   └── auth.py          # Tesla authentication
+│   ├── tak_client.py     # TAK server connection
+│   ├── health.py         # Health monitor + failure alerting
+│   ├── constants.py      # Shared physical constants
+│   ├── utils.py          # Helper functions
+│   └── auth.py           # Tesla authentication
 ├── teslaontarget.sh     # Single control script (start/stop/status)
 ├── config.py            # Your configuration (don't commit!)
 ├── pyproject.toml       # Project metadata & dependencies (uv)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,29 @@ Bridge your Tesla vehicle with TAK (Team Awareness Kit) servers for real-time po
 
 TeslaOnTarget connects your Tesla to a TAK server and streams live position and status as Cursor-on-Target (CoT) messages — for emergency response, fleet or personal tracking, or testing TAK systems with real vehicle data.
 
+## How it works
+
+```mermaid
+flowchart LR
+    tesla["Tesla Owner API"]
+    subgraph app["TeslaOnTarget container"]
+        cli["cli<br/>per-vehicle threads"]
+        api["tesla_api<br/>poll + dead reckoning"]
+        mapper["vehicle_mapper<br/>payload to CoT dict"]
+        cot["cot<br/>build CoT XML"]
+        takc["tak_client<br/>TCP send"]
+        health["health<br/>monitor + alerts"]
+        cli --> api --> mapper --> cot --> takc
+        health -.->|watches| takc
+    end
+    tesla -->|vehicle data every 10s| cli
+    takc -->|CoT over TCP| takserver["TAK Server"]
+    takserver --> clients["ATAK / iTAK / WebTAK"]
+    health -.->|webhook/ntfy on stall| alert["Alert endpoint"]
+```
+
+Poll Tesla → map the payload to a CoT event → send it to your TAK server, with 1 Hz dead-reckoning between polls and a health monitor that reconnects (and alerts) on failure. Full detail: **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+
 ## Features
 
 - **Real-time tracking** — GPS updates every 10s with 1Hz dead-reckoning in between
@@ -37,7 +60,7 @@ docker run -d --env-file .env -v tesla_data:/data -v tesla_logs:/logs \
   --name teslaontarget --restart unless-stopped ghcr.io/joshuafuller/teslaontarget
 ```
 
-Prefer a non-Docker install? `uv sync`, then `cp config.py.template config.py` and `python -m teslaontarget.auth`. Full guides below.
+Prefer a non-Docker install? `uv sync`, copy `config.py.template` → `config.py`, run `python -m teslaontarget.auth`, then `./teslaontarget.sh start`. Full guides below.
 
 ## Requirements
 
@@ -55,7 +78,8 @@ Set via environment variables (Docker) or `config.py` (source). The essentials:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `TAK_SERVER` / `COT_URL` | TAK server host (or full `tcp://host:port`) | required |
+| `TAK_SERVER` (+ `TAK_PORT`) | TAK server host/IP and port — **Docker** | required |
+| `COT_URL` | Full `tcp://host:port` — **source** `config.py` | required |
 | `TESLA_USERNAME` | Tesla account email | required |
 | `ALERT_WEBHOOK_URL` | ntfy topic / webhook for failure alerts | _(off)_ |
 
@@ -64,7 +88,7 @@ Full reference (all options, multi-vehicle filtering, debug capture, what's tran
 ## Documentation
 
 - **[Documentation index](docs/README.md)** — start here
-- [Docker guide](docs/DOCKER.md) · [Tesla authentication](docs/AUTHENTICATION.md) · [Configuration & operations](docs/CONFIGURATION.md) · [Troubleshooting](docs/TROUBLESHOOTING.md)
+- [Architecture](docs/ARCHITECTURE.md) · [Docker guide](docs/DOCKER.md) · [Tesla authentication](docs/AUTHENTICATION.md) · [Configuration & operations](docs/CONFIGURATION.md) · [Troubleshooting](docs/TROUBLESHOOTING.md)
 - [CHANGELOG](CHANGELOG.md) · [Releases](https://github.com/joshuafuller/TeslaOnTarget/releases) · [Roadmap](docs/ROADMAP.md) · [Contributing](CONTRIBUTING.md)
 
 ## Known limitations

--- a/config.py.template
+++ b/config.py.template
@@ -25,7 +25,7 @@ DEAD_RECKONING_DELAY = 1  # Seconds between dead reckoning updates
 LAST_POSITION_FILE = "last_known_position.json"  # Cache file for last position
 
 # Debug Settings
-DEBUG_MODE = True  # Save all Tesla API responses to tesla_api_captures/ directory
+DEBUG_MODE = False  # Set True to save every Tesla API response to tesla_api_captures/ (debugging only)
 
 # Constants (don't change these)
 MPH_TO_MS = 0.44704  # Conversion factor from mph to m/s

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,80 @@
+# Architecture
+
+TeslaOnTarget is a small, single-purpose bridge: it polls the Tesla Owner API, turns each response into a Cursor-on-Target (CoT) event, and streams it to a TAK server — with smoothing between polls and self-healing on failure.
+
+## System overview
+
+```mermaid
+flowchart LR
+    tesla["Tesla Owner API"]
+    subgraph app["TeslaOnTarget container"]
+        cli["cli<br/>per-vehicle threads"]
+        api["tesla_api<br/>poll + dead reckoning"]
+        mapper["vehicle_mapper<br/>payload to CoT dict"]
+        cot["cot<br/>build CoT XML"]
+        takc["tak_client<br/>TCP send"]
+        health["health<br/>monitor + alerts"]
+        cli --> api --> mapper --> cot --> takc
+        health -.->|watches| takc
+    end
+    tesla -->|vehicle data every 10s| cli
+    takc -->|CoT over TCP| takserver["TAK Server"]
+    takserver --> clients["ATAK / iTAK / WebTAK"]
+    health -.->|webhook/ntfy on stall| alert["Alert endpoint"]
+```
+
+## Modules
+
+| Module | Responsibility |
+|--------|----------------|
+| `cli` | Startup, config load + validation, one daemon tracking thread per vehicle, shared TAK client + health monitor |
+| `config_handler` | Immutable `AppConfig` (frozen dataclass) + `load_config()` — config is loaded once and injected, never mutated globally |
+| `tesla_api` (`TeslaCoT`) | Polls the vehicle, orchestrates the per-cycle flow, runs dead-reckoning interpolation, classifies/handles API errors |
+| `vehicle_mapper` | Pure functions mapping a raw Tesla payload → the flat CoT data dict (no I/O, independently testable) |
+| `cot` | Builds the CoT XML event and frames it for TAK |
+| `tak_client` | TCP connection to the TAK server; fail-fast send with background reconnect |
+| `health` | Background monitor: detects stalled sends, forces reconnect, alerts, and exits for a supervisor restart when critical |
+| `constants` | Shared physical constants (unit conversions, Earth radius) |
+| `auth` | Interactive Tesla OAuth token setup |
+
+## Runtime flow
+
+```mermaid
+sequenceDiagram
+    participant T as Tesla API
+    participant P as Poller (tesla_api)
+    participant K as TAK client
+    participant H as Health monitor
+    loop every API_LOOP_DELAY (~10s)
+        P->>T: get_vehicle_data
+        T-->>P: position + state
+        P->>K: send CoT
+        opt dead reckoning enabled
+            loop 1 Hz until next poll
+                P->>K: interpolated CoT
+            end
+        end
+    end
+    H->>K: check last successful send
+    alt stalled beyond threshold
+        H->>K: force reconnect
+        H->>H: alert, then restart if critical
+    end
+```
+
+**Dead reckoning** smooths the display between the 10-second API polls: while the vehicle moves, the poller projects position forward from the last known point using speed + heading and emits ~1 Hz CoT updates, so the marker glides instead of jumping.
+
+**Resilience** is layered: `tak_client.send_cot` never blocks — on failure it marks itself disconnected, kicks an idempotent background reconnect, and returns. The `health` monitor independently watches the time since the last successful send and escalates: force-reconnect → alert → restart-for-recovery. See [CONFIGURATION.md](CONFIGURATION.md) for the thresholds and `ALERT_WEBHOOK_URL`.
+
+## Release & delivery
+
+```mermaid
+flowchart TD
+    commit["Conventional commit merged to main"] --> rp["release-please"]
+    rp --> pr["Release PR<br/>(version bump + CHANGELOG)"]
+    pr -->|merge when ready| rel["Tag vX.Y.Z + GitHub Release"]
+    rel --> img["Publish GHCR image<br/>X.Y.Z / X.Y / X / latest"]
+    img --> pull["Pull / deploy"]
+```
+
+Versioning and the CHANGELOG are generated from Conventional Commits by release-please; merging the release PR tags the release and publishes the multi-arch GHCR image. CI also enforces 100% line+branch test coverage, a mutation gate, and Trivy security scanning on every PR.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -64,7 +64,7 @@ sequenceDiagram
 
 **Dead reckoning** smooths the display between the 10-second API polls: while the vehicle moves, the poller projects position forward from the last known point using speed + heading and emits ~1 Hz CoT updates, so the marker glides instead of jumping.
 
-**Resilience** is layered: `tak_client.send_cot` never blocks — on failure it marks itself disconnected, kicks an idempotent background reconnect, and returns. The `health` monitor independently watches the time since the last successful send and escalates: force-reconnect → alert → restart-for-recovery. See [CONFIGURATION.md](CONFIGURATION.md) for the thresholds and `ALERT_WEBHOOK_URL`.
+**Resilience** is layered: `tak_client.send_cot` never loops or waits on a dead server — at most one bounded connection attempt (10s socket timeout), and on failure it marks itself disconnected, kicks an idempotent background reconnect, and returns. The `health` monitor independently watches the time since the last successful send and escalates: force-reconnect → alert → restart-for-recovery. See [CONFIGURATION.md](CONFIGURATION.md) for the thresholds and `ALERT_WEBHOOK_URL`.
 
 ## Release & delivery
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,7 +27,7 @@ Set `ALERT_WEBHOOK_URL` to an [ntfy](https://ntfy.sh) topic or any webhook to be
 
 ## TAK server setup
 
-- Configure a **TCP input** on your chosen port (default `8085`).
+- Configure a **plaintext TCP input** on whatever port your TAK server uses, and point `COT_URL` / `TAK_PORT` at it. (`8085` is just the value used in these examples and in `.env.example` — set it to your own.)
 - Plaintext only — keep TAK traffic on the local network.
 - TAK clients must share the network with (or have routing to) the server.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,75 @@
+# Configuration & Operations
+
+Settings can be provided as **environment variables** (Docker, via `.env`) or in a **`config.py`** file (source installs — `cp config.py.template config.py`).
+
+## Configuration options
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `COT_URL` | TAK server URL (`tcp://host:port`) | `tcp://YOUR_TAK_SERVER:8085` |
+| `TESLA_USERNAME` | Your Tesla account email | required |
+| `API_LOOP_DELAY` | Seconds between Tesla API calls | `10` |
+| `LAST_POSITION_FILE` | Cache file for position data | `last_known_position.json` |
+| `DEBUG_MODE` | Save all Tesla API responses for analysis | `False` |
+| `DEAD_RECKONING_ENABLED` | Interpolate position between API updates | `True` (Docker default) |
+| `DEAD_RECKONING_DELAY` | Seconds between interpolated updates (1 = 1Hz) | `1` |
+| `ALERT_WEBHOOK_URL` | ntfy topic / webhook for failure alerts (empty = disabled) | _(empty)_ |
+| `HEALTH_NO_SEND_SECONDS` | Stall threshold before forcing a reconnect (0 = auto) | `0` |
+| `HEALTH_CHECK_INTERVAL` | Seconds between health checks (0 = auto) | `0` |
+| `HEALTH_HARD_RESTART_SECONDS` | No-send threshold before exiting for a supervisor restart (0 = auto) | `0` |
+| `HEALTH_FILE` | Path to the health snapshot file | `health.json` |
+
+In Docker, `TAK_SERVER` + `TAK_PORT` are combined into `COT_URL` by the entrypoint.
+
+## Failure alerting
+
+Set `ALERT_WEBHOOK_URL` to an [ntfy](https://ntfy.sh) topic or any webhook to be paged when the health monitor detects a prolonged send stall or triggers a recovery restart. Empty (the default) disables alerting.
+
+## TAK server setup
+
+- Configure a **TCP input** on your chosen port (default `8085`).
+- Plaintext only — keep TAK traffic on the local network.
+- TAK clients must share the network with (or have routing to) the server.
+
+## Management commands (source install)
+
+```bash
+./teslaontarget.sh start     # start tracking in background
+./teslaontarget.sh stop      # stop
+./teslaontarget.sh restart   # restart
+./teslaontarget.sh status    # check if running
+./teslaontarget.sh logs      # live logs
+python3 -m teslaontarget.auth  # set up / refresh Tesla auth
+```
+
+For Docker, use `./docker-run.sh {build,auth,start,logs,status}` or `docker compose`.
+
+## Verifying it works
+
+1. Logs show `Connected to TAK server` and `Successfully sent CoT packet`.
+2. Your vehicle appears on the map in iTAK/ATAK/WebTAK and updates every ~10s.
+
+## Multi-vehicle support
+
+By default all vehicles on the account are tracked. Filter with `VEHICLE_FILTER`:
+
+```python
+VEHICLE_FILTER = []                                   # all (default)
+VEHICLE_FILTER = ["Model Y", "Cybertruck"]            # by display name
+VEHICLE_FILTER = ["5YJ3E1EA8NF000000"]                # by VIN
+```
+
+Each vehicle gets its own CoT identifier, its own position cache (`last_position_<VIN>.json`), and its own thread, sharing one TAK connection.
+
+## Data transmitted
+
+Each CoT message includes: GPS position, heading, speed (when moving), battery level, charging state, and the vehicle name as callsign.
+
+## Debug mode & data capture
+
+With `DEBUG_MODE = True`, every Tesla API response is saved to `tesla_api_captures/` for debugging and replay:
+
+```bash
+python3 tools/replay_captures.py         # quick view of extracted data
+python3 tools/analyze_full_captures.py   # full field analysis across captures
+```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,7 +6,7 @@ Settings can be provided as **environment variables** (Docker, via `.env`) or in
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `COT_URL` | TAK server URL (`tcp://host:port`) | `tcp://<tak-host>:8085` (placeholder) |
+| `COT_URL` | TAK server URL (`tcp://host:port`) | `tcp://YOUR_TAK_SERVER_IP:8085` (placeholder, per `config.py.template`) |
 | `TESLA_USERNAME` | Your Tesla account email | required |
 | `API_LOOP_DELAY` | Seconds between Tesla API calls | `10` |
 | `LAST_POSITION_FILE` | Cache file for position data | `last_known_position.json` |
@@ -19,7 +19,7 @@ Settings can be provided as **environment variables** (Docker, via `.env`) or in
 | `HEALTH_HARD_RESTART_SECONDS` | No-send threshold before exiting for a supervisor restart (0 = auto) | `0` |
 | `HEALTH_FILE` | Path to the health snapshot file | `health.json` |
 
-In Docker, `TAK_SERVER` + `TAK_PORT` are combined into `COT_URL` by the entrypoint.
+In Docker, `TAK_SERVER` + `TAK_PORT` are combined into `COT_URL` by the entrypoint, which also writes container paths regardless of the values above: `LAST_POSITION_FILE=/data/last_known_position.json` and `HEALTH_FILE=/logs/health.json`.
 
 ## Failure alerting
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,12 +6,12 @@ Settings can be provided as **environment variables** (Docker, via `.env`) or in
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `COT_URL` | TAK server URL (`tcp://host:port`) | `tcp://YOUR_TAK_SERVER:8085` |
+| `COT_URL` | TAK server URL (`tcp://host:port`) | `tcp://<tak-host>:8085` (placeholder) |
 | `TESLA_USERNAME` | Your Tesla account email | required |
 | `API_LOOP_DELAY` | Seconds between Tesla API calls | `10` |
 | `LAST_POSITION_FILE` | Cache file for position data | `last_known_position.json` |
 | `DEBUG_MODE` | Save all Tesla API responses for analysis | `False` |
-| `DEAD_RECKONING_ENABLED` | Interpolate position between API updates | `True` (Docker default) |
+| `DEAD_RECKONING_ENABLED` | Interpolate position between API updates | `False` (the `config.py.template` and Docker set `True`) |
 | `DEAD_RECKONING_DELAY` | Seconds between interpolated updates (1 = 1Hz) | `1` |
 | `ALERT_WEBHOOK_URL` | ntfy topic / webhook for failure alerts (empty = disabled) | _(empty)_ |
 | `HEALTH_NO_SEND_SECONDS` | Stall threshold before forcing a reconnect (0 = auto) | `0` |

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@
 - [AUTHENTICATION.md](AUTHENTICATION.md) - Tesla authentication guide
 - [DOCKER.md](DOCKER.md) - Complete Docker guide
 - [DOCKER_QUICKSTART.md](DOCKER_QUICKSTART.md) - Docker quick reference
+- [CONFIGURATION.md](CONFIGURATION.md) - All settings, multi-vehicle, debug mode, operations
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Common problems and fixes
 
 ### Development
 - [CONTRIBUTING.md](../CONTRIBUTING.md) - How to contribute

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 
 ### Getting Started
 - [Main README](../README.md) - Project overview and quick start
+- [ARCHITECTURE.md](ARCHITECTURE.md) - How it works: modules, runtime flow, diagrams
 - [AUTHENTICATION.md](AUTHENTICATION.md) - Tesla authentication guide
 - [DOCKER.md](DOCKER.md) - Complete Docker guide
 - [DOCKER_QUICKSTART.md](DOCKER_QUICKSTART.md) - Docker quick reference

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 ## Vehicle not appearing in TAK
 
-1. Check connectivity to the TAK server: `telnet <tak-host> <port>` (default port `8085`).
+1. Check connectivity to the TAK server: `telnet <tak-host> <port>` (use whatever plaintext port your TAK server listens on — `8085` in these examples).
 2. Verify the vehicle is online in the Tesla app.
 3. Check logs: `./teslaontarget.sh logs` (or `./docker-run.sh logs`) — look for `Successfully sent CoT packet`.
 4. Confirm your TAK client is connected to the same server.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -10,9 +10,17 @@
 
 ## Authentication issues
 
+**Source install** — clear the cached token and re-authenticate:
+
 ```bash
 rm cache.json
 python3 -m teslaontarget.auth
+```
+
+**Docker** — the token lives in the `tesla_data` volume; re-run the auth container:
+
+```bash
+docker run -it --env-file .env -v tesla_data:/data ghcr.io/joshuafuller/teslaontarget auth
 ```
 
 See [AUTHENTICATION.md](AUTHENTICATION.md) for the full login walkthrough.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -2,7 +2,7 @@
 
 ## Vehicle not appearing in TAK
 
-1. Check connectivity to the TAK server: `telnet your-tak-server 8085`.
+1. Check connectivity to the TAK server: `telnet <tak-host> <port>` (default port `8085`).
 2. Verify the vehicle is online in the Tesla app.
 3. Check logs: `./teslaontarget.sh logs` (or `./docker-run.sh logs`) — look for `Successfully sent CoT packet`.
 4. Confirm your TAK client is connected to the same server.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,32 @@
+# Troubleshooting
+
+## Vehicle not appearing in TAK
+
+1. Check connectivity to the TAK server: `telnet your-tak-server 8085`.
+2. Verify the vehicle is online in the Tesla app.
+3. Check logs: `./teslaontarget.sh logs` (or `./docker-run.sh logs`) — look for `Successfully sent CoT packet`.
+4. Confirm your TAK client is connected to the same server.
+5. If the app logs successful sends but you don't see it: refresh the TAK client (a stale client clock can hide markers whose `stale` time has passed).
+
+## Authentication issues
+
+```bash
+rm cache.json
+python3 -m teslaontarget.auth
+```
+
+See [AUTHENTICATION.md](AUTHENTICATION.md) for the full login walkthrough.
+
+## Vehicle shows the wrong location
+
+- The vehicle may be in a parking garage with no GPS.
+- Wait ~10s for the next update.
+
+## High Tesla battery drain
+
+- Normal: the vehicle is woken only once, on startup.
+- Abnormal: check logs for repeated wake attempts, then restart the service.
+
+## Connection keeps dropping
+
+The client fails fast and reconnects in the background. Persistent drops usually mean the TAK server is unreachable or restarting — verify the server and the network path. The health monitor will force reconnects and, after a prolonged stall, exit for a supervisor restart (set `ALERT_WEBHOOK_URL` to be paged when this happens — see [CONFIGURATION.md](CONFIGURATION.md)).


### PR DESCRIPTION
Brings the README in line with the codebase after the refactor/robustness/release work:
- **Python 3.7+ → 3.11+** (badge + requirements) — matches `pyproject` / the 3.14 runtime.
- **Fix placeholder support links** (`yourusername` → `joshuafuller`).
- **Document health monitor + alerting** (Features + `ALERT_WEBHOOK_URL` / `HEALTH_*` config).
- **Project structure** now lists all modules (adds `cli`, `health`, `vehicle_mapper`, `constants`).
- **Badges** for CI / security / release; note pinning a versioned GHCR image.

Docs-only; no code change.